### PR TITLE
Fix/audio buffer deallocation

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioDecoder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioDecoder.cpp
@@ -109,39 +109,4 @@ std::shared_ptr<AudioBus> AudioDecoder::decodeWithMemoryBlock(
   return audioBus;
 }
 
-// std::shared_ptr<AudioBus> AudioDecoder::decode(ma_decoder &decoder) const {
-// ma_uint64 totalFrameCount;
-// ma_decoder_get_length_in_pcm_frames(&decoder, &totalFrameCount);
-//
-// auto audioBus = std::make_shared<AudioBus>(
-//         static_cast<int>(totalFrameCount), 2, sampleRate_);
-// auto *buffer = new float[totalFrameCount * 2];
-//
-// ma_uint64 framesDecoded;
-// ma_decoder_read_pcm_frames(&decoder, buffer, totalFrameCount,
-// &framesDecoded); if (framesDecoded == 0) {
-//     __android_log_print(
-//             ANDROID_LOG_ERROR,
-//             "AudioDecoder",
-//             "Failed to decode");
-//
-//     delete[] buffer;
-//     ma_decoder_uninit(&decoder);
-//
-//     return nullptr;
-// }
-//
-// for (int i = 0; i < decoder.outputChannels; ++i) {
-//     auto channelData = audioBus->getChannel(i)->getData();
-//
-//     for (ma_uint64 j = 0; j < framesDecoded; ++j) {
-//         channelData[j] = buffer[j * decoder.outputChannels + i];
-//     }
-// }
-//
-// delete[] buffer;
-// ma_decoder_uninit(&decoder);
-//
-// return audioBus;
-// }
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferHostObject.h
@@ -31,6 +31,10 @@ class AudioBufferHostObject : public JsiHostObject {
         JSI_EXPORT_FUNCTION(AudioBufferHostObject, copyToChannel));
   }
 
+  [[nodiscard]] size_t getSizeInBytes() const {
+    return audioBuffer_->getLength() * audioBuffer_->getNumberOfChannels() * sizeof(float);
+  }
+
   JSI_PROPERTY_GETTER(sampleRate) {
     return {audioBuffer_->getSampleRate()};
   }
@@ -48,8 +52,6 @@ class AudioBufferHostObject : public JsiHostObject {
   }
 
   JSI_HOST_FUNCTION(getChannelData) {
-    // this method could cause a crash if channelData is already deallocated,
-    // but we handle deallocation internally so it should be safe
     auto channel = static_cast<int>(args[0].getNumber());
     auto channelData = reinterpret_cast<uint8_t *>(audioBuffer_->getChannelData(channel));
     auto length = static_cast<int>(audioBuffer_->getLength());

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/BaseAudioContextHostObject.h
@@ -109,7 +109,11 @@ class BaseAudioContextHostObject : public JsiHostObject {
     auto sampleRate = static_cast<float>(args[2].getNumber());
     auto buffer = BaseAudioContext::createBuffer(numberOfChannels, length, sampleRate);
     auto bufferHostObject = std::make_shared<AudioBufferHostObject>(buffer);
-    return jsi::Object::createFromHostObject(runtime, bufferHostObject);
+
+    auto jsiObject = jsi::Object::createFromHostObject(runtime, bufferHostObject);
+    jsiObject.setExternalMemoryPressure(runtime, bufferHostObject->getSizeInBytes());
+
+    return jsiObject;
   }
 
   JSI_HOST_FUNCTION(createPeriodicWave) {
@@ -158,7 +162,9 @@ class BaseAudioContextHostObject : public JsiHostObject {
         }
 
         promise->resolve([audioBufferHostObject = std::move(audioBufferHostObject)](jsi::Runtime &runtime) {
-          return jsi::Object::createFromHostObject(runtime, audioBufferHostObject);
+          auto jsiObject = jsi::Object::createFromHostObject(runtime, audioBufferHostObject);
+          jsiObject.setExternalMemoryPressure(runtime, audioBufferHostObject->getSizeInBytes());
+          return jsiObject;
         });
       }).detach();
     });
@@ -182,7 +188,9 @@ class BaseAudioContextHostObject : public JsiHostObject {
           }
 
           promise->resolve([audioBufferHostObject = std::move(audioBufferHostObject)](jsi::Runtime &runtime) {
-            return jsi::Object::createFromHostObject(runtime, audioBufferHostObject);
+            auto jsiObject = jsi::Object::createFromHostObject(runtime, audioBufferHostObject);
+            jsiObject.setExternalMemoryPressure(runtime, audioBufferHostObject->getSizeInBytes());
+            return jsiObject;
           });
         }).detach();
       });

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioNode.h
@@ -32,7 +32,7 @@ class AudioNode : public std::enable_shared_from_this<AudioNode> {
 
   bool isEnabled() const;
   void enable();
-  void disable();
+  virtual void disable();
 
  protected:
   friend class AudioNodeManager;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/PeriodicWave.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/PeriodicWave.cpp
@@ -121,7 +121,7 @@ int PeriodicWave::getNumberOfPartialsPerRange(int rangeIndex) const {
 
   // The very top range will have all the partials culled.
   int numberOfPartials =
-      floor(static_cast<float>(getMaxNumberOfPartials()) * cullingScale);
+      int(static_cast<float>(getMaxNumberOfPartials()) * cullingScale);
 
   return numberOfPartials;
 }

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.h
@@ -30,6 +30,7 @@ class AudioBufferSourceNode : public AudioScheduledSourceNode {
   void setBuffer(const std::shared_ptr<AudioBuffer> &buffer);
 
   void start(double when, double offset, double duration = -1);
+  void disable() override;
 
  protected:
   std::mutex &getBufferLock();

--- a/packages/react-native-audio-api/common/cpp/audioapi/jsi/JsiHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/jsi/JsiHostObject.h
@@ -48,6 +48,7 @@ using namespace facebook;
 class JsiHostObject : public jsi::HostObject {
  public:
   JsiHostObject();
+  ~JsiHostObject() override;
 
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Added `setExternalMemoryPressure` call when creating AudioBuffer jsi object. It notifies JS garbage collector about real size in bytes of that object (including audio data size).
- Added debugging jsi deallocation code section

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
