### PR TITLE
fix: fixed resultBus_ initializing, it should happen after sampleRate

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.cpp
@@ -25,13 +25,11 @@ OfflineAudioContext::OfflineAudioContext(
     : BaseAudioContext(),
       length_(length),
       numberOfChannels_(numberOfChannels),
-      currentSampleFrame_(0),
-      resultBus_(std::make_shared<AudioBus>(
-          static_cast<int>(length_),
-          numberOfChannels_,
-          sampleRate_)) {
+      currentSampleFrame_(0) {
   sampleRate_ = sampleRate;
   audioDecoder_ = std::make_shared<AudioDecoder>(sampleRate_);
+  resultBus_ = std::make_shared<AudioBus>(
+      static_cast<int>(length_), numberOfChannels_, sampleRate_);
 }
 
 OfflineAudioContext::~OfflineAudioContext() {


### PR DESCRIPTION


<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Initialize `resutBus_` after `sampleRate_`

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
