### PR TITLE
fix: create thread on constructor, after others are initialized

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeDestructor.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeDestructor.cpp
@@ -4,9 +4,9 @@
 
 namespace audioapi {
 
-AudioNodeDestructor::AudioNodeDestructor()
-    : thread_(std::thread(&AudioNodeDestructor::process, this)),
-      isExiting_(false) {}
+AudioNodeDestructor::AudioNodeDestructor(): isExiting_(false) {
+  thread_ = std::thread(&AudioNodeDestructor::process, this);
+}
 
 AudioNodeDestructor::~AudioNodeDestructor() {
   isExiting_ = true;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- `AudioNodeDestructor::thread_` is initialized on initialization list, while its thread captures `this` itself.
I've experienced app crash on iOS, at line `cv_.wait(lock, [this] {`


```cpp
void AudioNodeDestructor::process() {
  std::unique_lock<std::mutex> lock(mutex_);
  while (!isExiting_) {
    cv_.wait(lock, [this] {
      return isExiting_ || !nodesForDeconstruction_.empty();
    });

    if (isExiting_)
      break;

    if (!isExiting_ && !nodesForDeconstruction_.empty()) {
      nodesForDeconstruction_.clear();
    }
  }
}
```

with error 
```
libc++abi: terminating due to uncaught exception of type std::__1::system_error: condition_variable wait failed: Invalid argument
```

It seems like a thread trying to access some uninitialized value of `this` .
After moving code to initialize thread on its constructor, no more crash happened.



## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
