### PR TITLE
Chore/cmake cxx flags

### DIFF
--- a/packages/react-native-audio-api/android/CMakeLists.txt
+++ b/packages/react-native-audio-api/android/CMakeLists.txt
@@ -15,7 +15,7 @@ include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})
 
 string(APPEND CMAKE_CXX_FLAGS
-       "-fexceptions -frtti -std=c++${CMAKE_CXX_STANDARD} -Wall")
+       "-frtti -std=c++${CMAKE_CXX_STANDARD} -Wall")
 
 if(${IS_NEW_ARCHITECTURE_ENABLED})
   string(APPEND CMAKE_CXX_FLAGS " -DRCT_NEW_ARCH_ENABLED")

--- a/packages/react-native-audio-api/android/CMakeLists.txt
+++ b/packages/react-native-audio-api/android/CMakeLists.txt
@@ -14,6 +14,9 @@ endif()
 include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})
 
+# frtti - enable Run-Time Type Information (dynamic_cast, typeid)
+# -std=c++20 - use C++20 standard
+# -Wall - enable all compiler's warning messages
 string(APPEND CMAKE_CXX_FLAGS
        "-frtti -std=c++${CMAKE_CXX_STANDARD} -Wall")
 

--- a/packages/react-native-audio-api/android/CMakeLists.txt
+++ b/packages/react-native-audio-api/android/CMakeLists.txt
@@ -15,7 +15,7 @@ include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})
 
 string(APPEND CMAKE_CXX_FLAGS
-       " -fexceptions -frtti -std=c++${CMAKE_CXX_STANDARD} -Wall")
+       "-fexceptions -frtti -std=c++${CMAKE_CXX_STANDARD} -Wall")
 
 if(${IS_NEW_ARCHITECTURE_ENABLED})
   string(APPEND CMAKE_CXX_FLAGS " -DRCT_NEW_ARCH_ENABLED")

--- a/packages/react-native-audio-api/android/CMakeLists.txt
+++ b/packages/react-native-audio-api/android/CMakeLists.txt
@@ -14,6 +14,9 @@ endif()
 include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})
 
+string(APPEND CMAKE_CXX_FLAGS
+       " -fexceptions -frtti -std=c++${CMAKE_CXX_STANDARD} -Wall")
+
 if(${IS_NEW_ARCHITECTURE_ENABLED})
   string(APPEND CMAKE_CXX_FLAGS " -DRCT_NEW_ARCH_ENABLED")
 endif()

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeDestructor.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeDestructor.cpp
@@ -4,7 +4,7 @@
 
 namespace audioapi {
 
-AudioNodeDestructor::AudioNodeDestructor(): isExiting_(false) {
+AudioNodeDestructor::AudioNodeDestructor() : isExiting_(false) {
   thread_ = std::thread(&AudioNodeDestructor::process, this);
 }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Added `frtti`, `std=c++${standard_version}`, `Wall` flags to `CMAKE_CXX_FLAGS`

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
