### PR TITLE
fix: onended callback calling twice

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
@@ -128,12 +128,7 @@ void AudioBufferSourceNode::start(double when, double offset, double duration) {
 }
 
 void AudioBufferSourceNode::disable() {
-  AudioNode::disable();
-
-  if (onendedCallback_) {
-    onendedCallback_(getStopTime());
-  }
-
+  AudioScheduledSourceNode::disable();
   alignedBus_.reset();
 }
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -141,12 +141,16 @@ void AudioScheduledSourceNode::updatePlaybackInfo(
   nonSilentFramesToProcess = framesToProcess;
 }
 
+void AudioScheduledSourceNode::disable() {
+  AudioNode::disable();
+
+  if (onendedCallback_) {
+    onendedCallback_(getStopTime());
+  }
+}
+
 void AudioScheduledSourceNode::handleStopScheduled() {
   if (isStopScheduled()) {
-    if (onendedCallback_) {
-      onendedCallback_(getStopTime());
-    }
-
     playbackState_ = PlaybackState::FINISHED;
     disable();
   }

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
@@ -33,6 +33,7 @@ class AudioScheduledSourceNode : public AudioNode {
   void setOnendedCallback(const std::function<void(double)> &onendedCallback);
 
   virtual double getStopTime() const = 0;
+  void disable() override;
 
  protected:
   PlaybackState playbackState_;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #357
Closes RNAA-40

## Introduced changes

<!-- A brief description of the changes -->

- Fixed calling `onended` callback twice

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
