### PR TITLE
fix: remove playing nodes from destruction

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.cpp
@@ -43,25 +43,25 @@ std::shared_ptr<AudioDestinationNode> BaseAudioContext::getDestination() {
 
 std::shared_ptr<OscillatorNode> BaseAudioContext::createOscillator() {
   auto oscillator = std::make_shared<OscillatorNode>(this);
-  nodeManager_->addNode(oscillator);
+  nodeManager_->addSourceNode(oscillator);
   return oscillator;
 }
 
 std::shared_ptr<GainNode> BaseAudioContext::createGain() {
   auto gain = std::make_shared<GainNode>(this);
-  nodeManager_->addNode(gain);
+  nodeManager_->addProcessingNode(gain);
   return gain;
 }
 
 std::shared_ptr<StereoPannerNode> BaseAudioContext::createStereoPanner() {
   auto stereoPanner = std::make_shared<StereoPannerNode>(this);
-  nodeManager_->addNode(stereoPanner);
+  nodeManager_->addProcessingNode(stereoPanner);
   return stereoPanner;
 }
 
 std::shared_ptr<BiquadFilterNode> BaseAudioContext::createBiquadFilter() {
   auto biquadFilter = std::make_shared<BiquadFilterNode>(this);
-  nodeManager_->addNode(biquadFilter);
+  nodeManager_->addProcessingNode(biquadFilter);
   return biquadFilter;
 }
 
@@ -69,7 +69,7 @@ std::shared_ptr<AudioBufferSourceNode> BaseAudioContext::createBufferSource(
     bool pitchCorrection) {
   auto bufferSource =
       std::make_shared<AudioBufferSourceNode>(this, pitchCorrection);
-  nodeManager_->addNode(bufferSource);
+  nodeManager_->addSourceNode(bufferSource);
   return bufferSource;
 }
 
@@ -90,7 +90,7 @@ std::shared_ptr<PeriodicWave> BaseAudioContext::createPeriodicWave(
 
 std::shared_ptr<AnalyserNode> BaseAudioContext::createAnalyser() {
   auto analyser = std::make_shared<AnalyserNode>(this);
-  nodeManager_->addNode(analyser);
+  nodeManager_->addProcessingNode(analyser);
   return analyser;
 }
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
@@ -18,6 +18,11 @@ namespace audioapi {
 
 class AudioScheduledSourceNode : public AudioNode {
  public:
+  // UNSCHEDULED: The node is not scheduled to play.
+  // SCHEDULED: The node is scheduled to play at a specific time.
+  // PLAYING: The node is currently playing.
+  // FINISHED: The node has finished playing.
+  // STOP_SCHEDULED: The node is scheduled to stop at a specific time, but is still playing.
   enum class PlaybackState { UNSCHEDULED, SCHEDULED, PLAYING, FINISHED, STOP_SCHEDULED };
   explicit AudioScheduledSourceNode(BaseAudioContext *context);
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/OscillatorNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/OscillatorNode.cpp
@@ -51,7 +51,7 @@ void OscillatorNode::processNode(
 
   updatePlaybackInfo(processingBus, framesToProcess, startOffset, offsetLength);
 
-  if (!isPlaying()) {
+  if (!isPlaying() && !isStopScheduled()) {
     processingBus->zero();
     return;
   }

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.cpp
@@ -1,7 +1,7 @@
 #include <audioapi/core/AudioNode.h>
+#include <audioapi/core/sources/AudioScheduledSourceNode.h>
 #include <audioapi/core/utils/AudioNodeManager.h>
 #include <audioapi/core/utils/Locker.h>
-#include <audioapi/core/sources/AudioScheduledSourceNode.h>
 
 namespace audioapi {
 
@@ -29,9 +29,16 @@ std::mutex &AudioNodeManager::getGraphLock() {
   return graphLock_;
 }
 
-void AudioNodeManager::addNode(const std::shared_ptr<AudioNode> &node) {
+void AudioNodeManager::addProcessingNode(
+    const std::shared_ptr<AudioNode> &node) {
   Locker lock(getGraphLock());
-  nodes_.insert(node);
+  processingNodes_.insert(node);
+}
+
+void AudioNodeManager::addSourceNode(
+    const std::shared_ptr<AudioScheduledSourceNode> &node) {
+  Locker lock(getGraphLock());
+  sourceNodes_.insert(node);
 }
 
 void AudioNodeManager::settlePendingConnections() {
@@ -55,19 +62,35 @@ void AudioNodeManager::settlePendingConnections() {
   audioNodesToConnect_.clear();
 }
 
+void AudioNodeManager::cleanupNode(const std::shared_ptr<AudioNode> &node) {
+  nodeDeconstructor_.addNodeForDeconstruction(node);
+  node.get()->cleanup();
+}
+
 void AudioNodeManager::prepareNodesForDestruction() {
   nodeDeconstructor_.tryCallWithLock([this]() {
-    auto it = nodes_.begin();
+    auto sNodesIt = sourceNodes_.begin();
 
-    while (it != nodes_.end()) {
-      std::shared_ptr<AudioScheduledSourceNode> nodePtr = std::dynamic_pointer_cast<AudioScheduledSourceNode>(*it);
-        //we don't want to destroy nodes that are still playing or will be playing
-        if (it->use_count() == 1 && ((nodePtr && (nodePtr->isFinished() || nodePtr->isUnscheduled())) || !nodePtr)) {
-          nodeDeconstructor_.addNodeForDeconstruction(*it);
-          it->get()->cleanup();
-          it = nodes_.erase(it);
+    while (sNodesIt != sourceNodes_.end()) {
+      // we don't want to destroy nodes that are still playing or will be
+      // playing
+      if (sNodesIt->use_count() == 1 &&
+          (sNodesIt->get()->isUnscheduled() || sNodesIt->get()->isFinished())) {
+        cleanupNode(*sNodesIt);
+        sNodesIt = sourceNodes_.erase(sNodesIt);
       } else {
-        ++it;
+        ++sNodesIt;
+      }
+    }
+
+    auto pNodesIt = processingNodes_.begin();
+
+    while (pNodesIt != processingNodes_.end()) {
+      if (pNodesIt->use_count() == 1) {
+        cleanupNode(*pNodesIt);
+        pNodesIt = processingNodes_.erase(pNodesIt);
+      } else {
+        ++pNodesIt;
       }
     }
   });
@@ -77,11 +100,19 @@ void AudioNodeManager::prepareNodesForDestruction() {
 void AudioNodeManager::cleanup() {
   Locker lock(getGraphLock());
 
-  for (auto it = nodes_.begin(), end = nodes_.end(); it != end; ++it) {
+  for (auto it = sourceNodes_.begin(), end = sourceNodes_.end(); it != end;
+       ++it) {
     it->get()->cleanup();
   }
 
-  nodes_.clear();
+  for (auto it = processingNodes_.begin(), end = processingNodes_.end();
+       it != end;
+       ++it) {
+    it->get()->cleanup();
+  }
+
+  sourceNodes_.clear();
+  processingNodes_.clear();
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.h
@@ -11,6 +11,7 @@
 namespace audioapi {
 
 class AudioNode;
+class AudioScheduledSourceNode;
 
 class AudioNodeManager {
  public:
@@ -27,7 +28,8 @@ class AudioNodeManager {
       const std::shared_ptr<AudioNode> &to,
       ConnectionType type);
 
-  void addNode(const std::shared_ptr<AudioNode> &node);
+  void addProcessingNode(const std::shared_ptr<AudioNode> &node);
+  void addSourceNode(const std::shared_ptr<AudioScheduledSourceNode> &node);
 
   void cleanup();
 
@@ -36,7 +38,8 @@ class AudioNodeManager {
   AudioNodeDestructor nodeDeconstructor_;
 
   // all nodes created in the context
-  std::unordered_set<std::shared_ptr<AudioNode>> nodes_;
+  std::unordered_set<std::shared_ptr<AudioScheduledSourceNode>> sourceNodes_;
+  std::unordered_set<std::shared_ptr<AudioNode>> processingNodes_;
 
   // connections to be settled
   std::vector<std::tuple<
@@ -46,6 +49,7 @@ class AudioNodeManager {
       audioNodesToConnect_;
 
   void settlePendingConnections();
+  void cleanupNode(const std::shared_ptr<AudioNode> &node);
   void prepareNodesForDestruction();
 };
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #400 
Closes RNAA-62

## Introduced changes

<!-- A brief description of the changes -->

- added checks during destruction in order not to destroy playing source nodes

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
