### PR TITLE
Fix/analyser node/wrong offset while copying

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/analysis/AnalyserNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/analysis/AnalyserNode.cpp
@@ -154,8 +154,10 @@ void AnalyserNode::processNode(
   // Down mix the input bus to mono
   downMixBus_->copy(processingBus.get());
 
+  auto framesToCopy = 0;
+
   if (vWriteIndex_ + framesToProcess > inputBuffer_->getSize()) {
-    auto framesToCopy =
+    framesToCopy =
         static_cast<int>(inputBuffer_->getSize()) - vWriteIndex_;
     memcpy(
         inputBuffer_->getData() + vWriteIndex_,
@@ -168,7 +170,7 @@ void AnalyserNode::processNode(
 
   memcpy(
       inputBuffer_->getData() + vWriteIndex_,
-      downMixBus_->getChannel(0)->getData(),
+      downMixBus_->getChannel(0)->getData() + framesToCopy,
       framesToProcess * sizeof(float));
 
   vWriteIndex_ += framesToProcess;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/analysis/AnalyserNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/analysis/AnalyserNode.cpp
@@ -157,8 +157,7 @@ void AnalyserNode::processNode(
   auto framesToCopy = 0;
 
   if (vWriteIndex_ + framesToProcess > inputBuffer_->getSize()) {
-    framesToCopy =
-        static_cast<int>(inputBuffer_->getSize()) - vWriteIndex_;
+    framesToCopy = static_cast<int>(inputBuffer_->getSize()) - vWriteIndex_;
     memcpy(
         inputBuffer_->getData() + vWriteIndex_,
         downMixBus_->getChannel(0)->getData(),


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Added correct offset while copying buffer in `AnalyserNode`

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
