### PR TITLE
docs: fix highlighted sections in lets-make-some-noise

### DIFF
--- a/packages/audiodocs/docs/guides/lets-make-some-noise.mdx
+++ b/packages/audiodocs/docs/guides/lets-make-some-noise.mdx
@@ -10,13 +10,15 @@ In this section, we will guide you through the basic concepts of Audio API. We a
 
 Let's start by bootstrapping a simple application with a play button and creating our first instance of `AudioContext` object.
 
-```jsx {1,5}
+```jsx
 import React from 'react';
 import { View, Button } from 'react-native';
+// highlight-next-line
 import { AudioContext } from 'react-native-audio-api';
 
 export default function App() {
   const handlePlay = async () => {
+    // highlight-next-line
     const audioContext = new AudioContext();
   };
 
@@ -34,7 +36,7 @@ export default function App() {
 
 Before we can play anything, we need to gain access to some audio data. For the purpose of this guide, we will first download it from a remote source using.
 
-```jsx {9-12}
+```jsx
 import React from 'react';
 import { View, Button } from 'react-native';
 import { AudioContext } from 'react-native-audio-api';
@@ -43,9 +45,11 @@ export default function App() {
   const handlePlay = async () => {
     const audioContext = new AudioContext();
 
+    // highlight-start
     const audioBuffer = await fetch('https://software-mansion.github.io/react-native-audio-api/audio/music/example-music-01.mp3')
       .then((response) => response.arrayBuffer())
       .then((arrayBuffer) => audioContext.decodeAudioData(arrayBuffer));
+    // highlight-end
   };
 
   return (


### PR DESCRIPTION
Fixed some tiny highlighting problems in docs

### Before

<img width="519" alt="image" src="https://github.com/user-attachments/assets/a431bff2-1503-44fa-9e94-e0e1f39d5340" />
<img width="531" alt="image" src="https://github.com/user-attachments/assets/e5861c7c-3da5-4b18-b11b-a1ddb33abbe5" />



### After

<img width="614" alt="Screenshot 2025-04-30 at 10 44 07" src="https://github.com/user-attachments/assets/f4a72483-50ff-4ebe-8e59-18e8c846a9ce" />
<img width="564" alt="Screenshot 2025-04-30 at 10 44 12" src="https://github.com/user-attachments/assets/044dd22c-088a-443c-924a-51991a798b7e" />