### PR TITLE
fix: get rid of round that caused frequency to be always int

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/OscillatorNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/OscillatorNode.cpp
@@ -63,8 +63,7 @@ void OscillatorNode::processNode(
   for (size_t i = startOffset; i < offsetLength; i += 1) {
     auto detuneRatio =
         std::pow(2.0f, detuneParam_->getValueAtTime(time) / 1200.0f);
-    auto detunedFrequency =
-        round(frequencyParam_->getValueAtTime(time) * detuneRatio);
+    auto detunedFrequency = frequencyParam_->getValueAtTime(time) * detuneRatio;
     auto phaseIncrement = detunedFrequency * periodicWave_->getScale();
 
     float sample =


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-104

## Introduced changes

<!-- A brief description of the changes -->

- get rid of a round function that caused oscillator node to always oscillate with integer frequencies (having fractional frequencies can be useful when dealing with LFOs when this parameter can be less than 1Hz)

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
