### PR TITLE
Feat/onended/added state to payload

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -152,9 +152,7 @@ void AudioScheduledSourceNode::disable() {
   }
 
   std::unordered_map<std::string, EventValue> body = {
-          {"value", getStopTime()},
-          {"state", state}
-  };
+      {"value", getStopTime()}, {"state", state}};
 
   context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
       "ended", onEndedCallbackId_, body);

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -144,7 +144,17 @@ void AudioScheduledSourceNode::updatePlaybackInfo(
 void AudioScheduledSourceNode::disable() {
   AudioNode::disable();
 
-  std::unordered_map<std::string, EventValue> body = {{"value", getStopTime()}};
+  std::string state = "stopped";
+
+  // if it has not been stopped, it is ended
+  if (stopTime_ < 0) {
+    state = "ended";
+  }
+
+  std::unordered_map<std::string, EventValue> body = {
+          {"value", getStopTime()},
+          {"state", state}
+  };
 
   context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
       "ended", onEndedCallbackId_, body);

--- a/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
@@ -1,7 +1,7 @@
 import { IAudioScheduledSourceNode } from '../interfaces';
 import AudioNode from './AudioNode';
 import { InvalidStateError, RangeError } from '../errors';
-import { EventTypeWithValue } from '../events/types';
+import { EventTypeWithValueAndState } from '../events/types';
 import { AudioEventEmitter } from '../events';
 
 export default class AudioScheduledSourceNode extends AudioNode {
@@ -42,7 +42,7 @@ export default class AudioScheduledSourceNode extends AudioNode {
   }
 
   // eslint-disable-next-line accessor-pairs
-  public set onended(callback: (event: EventTypeWithValue) => void) {
+  public set onended(callback: (event: EventTypeWithValueAndState) => void) {
     const subscription = this.audioEventEmitter.addAudioEventListener(
       'ended',
       callback

--- a/packages/react-native-audio-api/src/events/types.ts
+++ b/packages/react-native-audio-api/src/events/types.ts
@@ -6,6 +6,11 @@ export interface EventTypeWithValue {
   value: number;
 }
 
+export interface EventTypeWithValueAndState {
+  value: number;
+  state: 'stopped' | 'ended';
+}
+
 interface OnInterruptionEventType {
   type: 'ended' | 'began';
   shouldResume: boolean;
@@ -40,7 +45,7 @@ export interface OnAudioReadyEventType {
 }
 
 interface AudioAPIEvents {
-  ended: EventTypeWithValue;
+  ended: EventTypeWithValueAndState;
   audioReady: OnAudioReadyEventType;
   audioError: EventEmptyType; // to change
   systemStateChanged: EventEmptyType; // to change


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Added `state` prop to the payload of `onended` event. It will allow us to distinguish if `ABSN` has been stopped or it has ended by itself

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
