### PR TITLE
fix: added mutex in param for thread safety

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioParam.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioParam.cpp
@@ -1,5 +1,6 @@
 #include <audioapi/core/AudioParam.h>
 #include <audioapi/core/BaseAudioContext.h>
+#include <audioapi/core/utils/Locker.h>
 #include <audioapi/dsp/AudioUtils.h>
 #include <audioapi/dsp/VectorMath.h>
 #include <audioapi/utils/AudioArray.h>
@@ -47,11 +48,16 @@ float AudioParam::getMaxValue() const {
   return maxValue_;
 }
 
+std::mutex &AudioParam::getQueueLock() {
+  return queueLock_;
+}
+
 void AudioParam::setValue(float value) {
   value_ = std::clamp(value, minValue_, maxValue_);
 }
 
 float AudioParam::getValueAtTime(double time) {
+  Locker lock(getQueueLock());
   if (endTime_ < time && !eventsQueue_.empty()) {
     auto event = eventsQueue_.front();
     startTime_ = event.getStartTime();
@@ -84,6 +90,7 @@ void AudioParam::setValueAtTime(float value, double startTime) {
     return endValue;
   };
 
+  Locker lock(getQueueLock());
   auto event = ParamChangeEvent(
       startTime,
       startTime,
@@ -117,6 +124,7 @@ void AudioParam::linearRampToValueAtTime(float value, double endTime) {
     return endValue;
   };
 
+  Locker lock(getQueueLock());
   auto event = ParamChangeEvent(
       getQueueEndTime(),
       endTime,
@@ -151,6 +159,7 @@ void AudioParam::exponentialRampToValueAtTime(float value, double endTime) {
     return endValue;
   };
 
+  Locker lock(getQueueLock());
   auto event = ParamChangeEvent(
       getQueueEndTime(),
       endTime,
@@ -181,6 +190,7 @@ void AudioParam::setTargetAtTime(
             (startValue - target) * exp(-(time - startTime) / timeConstant));
       };
 
+  Locker lock(getQueueLock());
   auto event = ParamChangeEvent(
       startTime,
       startTime,
@@ -225,6 +235,7 @@ void AudioParam::setValueCurveAtTime(
     return endValue;
   };
 
+  Locker lock(getQueueLock());
   auto event = ParamChangeEvent(
       startTime,
       startTime + duration,
@@ -236,6 +247,7 @@ void AudioParam::setValueCurveAtTime(
 }
 
 void AudioParam::cancelScheduledValues(double cancelTime) {
+  Locker lock(getQueueLock());
   auto it = eventsQueue_.rbegin();
   while (it->getEndTime() >= cancelTime) {
     if (it->getStartTime() >= cancelTime ||
@@ -248,6 +260,7 @@ void AudioParam::cancelScheduledValues(double cancelTime) {
 }
 
 void AudioParam::cancelAndHoldAtTime(double cancelTime) {
+  Locker lock(getQueueLock());
   auto it = eventsQueue_.rbegin();
   while (it->getEndTime() >= cancelTime) {
     if (it->getStartTime() >= cancelTime) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioParam.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioParam.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <unordered_set>
 #include <cstddef>
+#include <mutex>
 
 namespace audioapi {
 
@@ -50,6 +51,7 @@ class AudioParam {
   std::deque<ParamChangeEvent> eventsQueue_;
   std::unordered_set<AudioNode *> inputNodes_;
   std::shared_ptr<AudioBus> audioBus_;
+  std::mutex queueLock_;
 
   double startTime_;
   double endTime_;
@@ -58,6 +60,7 @@ class AudioParam {
   std::function<float(double, double, float, float, double)> calculateValue_;
   std::vector<std::shared_ptr<AudioBus>> inputBuses_ = {};
 
+  std::mutex &getQueueLock();
   double getQueueEndTime();
   float getQueueEndValue();
   void updateQueue(ParamChangeEvent &event);

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.h
@@ -20,8 +20,6 @@ class AudioNodeManager {
   AudioNodeManager() = default;
   ~AudioNodeManager();
 
-  std::mutex &getGraphLock();
-
   void preProcessGraph();
 
   void addPendingNodeConnection(
@@ -62,6 +60,7 @@ class AudioNodeManager {
       ConnectionType>>
       audioParamToConnect_;
 
+  std::mutex &getGraphLock();
   void settlePendingConnections();
   void cleanupNode(const std::shared_ptr<AudioNode> &node);
   void prepareNodesForDestruction();


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-56

## Introduced changes

<!-- A brief description of the changes -->

- added mutex and logic behind locking functionalities that use eventsQueue, in order to not allow race condition between JS and audio thread

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
