### PR TITLE
feat: add haptics support for iOS audio sessions

### DIFF
--- a/packages/audiodocs/docs/system/audio-manager.mdx
+++ b/packages/audiodocs/docs/system/audio-manager.mdx
@@ -6,7 +6,7 @@ import { Optional, ReadOnly, OnlyiOS } from '@site/src/components/Badges';
 
 # AudioManager
 
-The `AudioManager` is a layer of an abstraction between user and a system.
+The `AudioManager` is a layer of an abstraction between user and a system. 
 It provides a set of system-specific functions that are invoked directly in native code, by related system.
 
 ## Example
@@ -16,22 +16,23 @@ import { AudioManager } from 'react-native-audio-api';
 import { useEffect } from 'react';
 
 function App() {
-  // set AVAudioSession example options (iOS only)
-  AudioManager.setAudioSessionOptions({
-    iosCategory: 'playback',
-    iosMode: 'default',
-    iosOptions: ['allowBluetooth', 'allowAirPlay'],
-  });
+    // set AVAudioSession example options (iOS only)
+    AudioManager.setAudioSessionOptions({
+      iosCategory: 'playback',
+      iosMode: 'default',
+      iosOptions: ['allowBluetooth', 'allowAirPlay'],
+    })
 
-  // set info for track to be visible while device is locked
-  AudioManager.setLockScreenInfo({
-    title: 'Audio file',
-    artist: 'Software Mansion',
-    album: 'Audio API',
-    duration: 10,
-  });
+    // set info for track to be visible while device is locked
+    AudioManager.setLockScreenInfo({
+        title: 'Audio file',
+        artist: 'Software Mansion',
+        album: 'Audio API',
+        duration: 10,
+    });
 
   useEffect(() => {
+
     // enabling emission of events
     AudioManager.enableRemoteCommand('remotePlay', true);
     AudioManager.enableRemoteCommand('remotePause', true);
@@ -61,6 +62,7 @@ function App() {
       }
     );
 
+
     return () => {
       remotePlaySubscription?.remove();
       remotePauseSubscription?.remove();
@@ -74,9 +76,9 @@ function App() {
 
 ### `setLockScreenInfo`
 
-| Parameters |                           Type                           |                  Description                   |
-| :--------: | :------------------------------------------------------: | :--------------------------------------------: |
-|   `info`   | [`LockScreenInfo`](/system/audio-manager#lockscreeninfo) | Information to be displayed on the lock screen |
+| Parameters | Type | Description |
+| :---: | :---: | :-----: |
+| `info` | [`LockScreenInfo`](/system/audio-manager#lockscreeninfo) | Information to be displayed on the lock screen |
 
 #### Returns `undefined`
 
@@ -88,17 +90,17 @@ Resets all of the lock screen data.
 
 ### `setAudioSessionOptions` <OnlyiOS />
 
-| Parameters |                           Type                           | Description                          |
-| :--------: | :------------------------------------------------------: | :----------------------------------- |
-|  options   | [`SessionOptions`](/system/audio-manager#sessionoptions) | Options to be set for AVAudioSession |
+| Parameters | Type | Description |
+| :---: | :---: | :---- |
+| options | [`SessionOptions`](/system/audio-manager#sessionoptions) | Options to be set for AVAudioSession |
 
 #### Returns `undefined`
 
 ### `setAudioSessionActivity` <OnlyiOS />
 
-| Parameters |   Type    | Description                                     |
-| :--------: | :-------: | :---------------------------------------------- |
-|  enabled   | `boolean` | It is used to set/unset AVAudioSession activity |
+| Parameters | Type | Description |
+| :---: | :---: | :---- |
+| enabled | `boolean` | It is used to set/unset AVAudioSession activity |
 
 #### Returns promise of `boolean` type, which is resolved to `true` if invokation ended with success, `false` otherwise.
 
@@ -108,17 +110,17 @@ Resets all of the lock screen data.
 
 ### `observeAudioInterruptions`
 
-| Parameters |   Type    | Description                                                |
-| :--------: | :-------: | :--------------------------------------------------------- |
-| `enabled`  | `boolean` | It is used to enable/disable observing audio interruptions |
+| Parameters | Type | Description |
+| :---: | :---: | :---- |
+| `enabled` | `boolean` | It is used to enable/disable observing audio interruptions |
 
 #### Returns `undefined`
 
 ### `observeVolumeChanges`
 
-| Parameters |   Type    | Description                                           |
-| :--------: | :-------: | :---------------------------------------------------- |
-| `enabled`  | `boolean` | It is used to enable/disable observing volume changes |
+| Parameters | Type | Description |
+| :---: | :---: | :---- |
+| `enabled` | `boolean` | It is used to enable/disable observing volume changes |
 
 #### Returns `undefined`
 
@@ -126,10 +128,10 @@ Resets all of the lock screen data.
 
 Enables emition of some system events.
 
-| Parameters |                                           Type                                            | Description                                      |
-| :--------: | :---------------------------------------------------------------------------------------: | :----------------------------------------------- |
-|   `name`   | [`RemoteCommandEventName`](/system/audio-manager#systemeventname--remotecommandeventname) | Name of an event                                 |
-| `enabled`  |                                         `boolean`                                         | Indicates the start or the end of event emission |
+| Parameters | Type | Description |
+| :---: | :---: | :---- |
+| `name` | [`RemoteCommandEventName`](/system/audio-manager#systemeventname--remotecommandeventname) | Name of an event |
+| `enabled` | `boolean` | Indicates the start or the end of event emission |
 
 #### Returns `undefined`
 
@@ -140,13 +142,14 @@ with proper parameters.
 
 :::
 
+
 ### `addSystemEventListener`
 
 Adds callback to be invoked upon hearing an event.
 
-| Parameters |                                          Type                                          | Description                                         |
-| :--------: | :------------------------------------------------------------------------------------: | :-------------------------------------------------- |
-|   `name`   |   [`SystemEventName`](/system/audio-manager#systemeventname--remotecommandeventname)   | Name of an event listener                           |
+| Parameters | Type | Description |
+| :---: | :---: | :---- |
+| `name` | [`SystemEventName`](/system/audio-manager#systemeventname--remotecommandeventname) | Name of an event listener |
 | `callback` | [`SystemEventCallback`](/system/audio-manager#systemeventname--remotecommandeventname) | Callback that will be invoked upon hearing an event |
 
 #### Returns [`AudioEventSubscription`](/system/audio-manager#audioeventsubscription) if `enabled` is set to true, `undefined` otherwise
@@ -179,21 +182,20 @@ interface BaseLockScreenInfo {
 type MediaState = 'state_playing' | 'state_paused';
 
 interface LockScreenInfo extends BaseLockScreenInfo {
-title?: string; //title of the track
-artwork?: string; //uri to the artwork
-artist?: string; //name of the artist
-album?: string; //name of the album
-duration?: number; //duration in seconds
-description?: string; // android only, description of the track
-state?: MediaState;
-speed?: number; //playback rate
-elapsedTime?: number; //elapsed time of an audio in seconds
+  title?: string; //title of the track
+  artwork?: string; //uri to the artwork
+  artist?: string; //name of the artist
+  album?: string; //name of the album
+  duration?: number; //duration in seconds
+  description?: string; // android only, description of the track
+  state?: MediaState;
+  speed?: number; //playback rate
+  elapsedTime?: number; //elapsed time of an audio in seconds
 }
-
-````
+```
 </details>
 
-### `SessionOptions`
+### `SessionOptions` 
 
 <details>
 <summary>Type definitions</summary>
@@ -232,9 +234,9 @@ interface SessionOptions {
   iosOptions?: IOSOption[];
   iosCategory?: IOSCategory;
 }
-````
-
+```
 </details>
+
 
 ### `SystemEventName` | `RemoteCommandEventName`
 
@@ -244,56 +246,55 @@ interface SessionOptions {
 interface EventEmptyType {}
 
 interface EventTypeWithValue {
-value: number;
+  value: number;
 }
 
 interface OnInterruptionEventType {
-type: 'ended' | 'began'; //if interruption event has started or ended
-shouldResume: boolean; //if we should resume playing after interruption
+  type: 'ended' | 'began'; //if interruption event has started or ended
+  shouldResume: boolean; //if we should resume playing after interruption
 }
 
 interface OnRouteChangeEventType {
-reason:
-| 'Unknown'
-| 'Override'
-| 'CategoryChange'
-| 'WakeFromSleep'
-| 'NewDeviceAvailable'
-| 'OldDeviceUnavailable'
-| 'ConfigurationChange'
-| 'NoSuitableRouteForCategory';
+  reason:
+    | 'Unknown'
+    | 'Override'
+    | 'CategoryChange'
+    | 'WakeFromSleep'
+    | 'NewDeviceAvailable'
+    | 'OldDeviceUnavailable'
+    | 'ConfigurationChange'
+    | 'NoSuitableRouteForCategory';
 }
 
 // visit https://developer.apple.com/documentation/mediaplayer/mpremotecommandcenter?language=objc
 // for further info
 interface RemoteCommandEvents {
-remotePlay: EventEmptyType;
-remotePause: EventEmptyType;
-remoteStop: EventEmptyType;
-remoteTogglePlayPause: EventEmptyType; // iOS only
-remoteChangePlaybackRate: EventTypeWithValue;
-remoteNextTrack: EventEmptyType;
-remotePreviousTrack: EventEmptyType;
-remoteSkipForward: EventTypeWithValue;
-remoteSkipBackward: EventTypeWithValue; // iOS only
-remoteSeekForward: EventEmptyType; // iOS only
-remoteSeekBackward: EventEmptyType;
-remoteChangePlaybackPosition: EventTypeWithValue;
+  remotePlay: EventEmptyType;
+  remotePause: EventEmptyType;
+  remoteStop: EventEmptyType;
+  remoteTogglePlayPause: EventEmptyType; // iOS only
+  remoteChangePlaybackRate: EventTypeWithValue;
+  remoteNextTrack: EventEmptyType;
+  remotePreviousTrack: EventEmptyType;
+  remoteSkipForward: EventTypeWithValue;
+  remoteSkipBackward: EventTypeWithValue; // iOS only
+  remoteSeekForward: EventEmptyType; // iOS only
+  remoteSeekBackward: EventEmptyType;
+  remoteChangePlaybackPosition: EventTypeWithValue;
 }
 
 type SystemEvents = RemoteCommandEvents & {
-volumeChange: EventTypeWithValue; //triggered when volume level is changed
-interruption: OnInterruptionEventType; //triggered when f.e. some app wants to play music when we are playing
-routeChange: OnRouteChangeEventType; //change of output f.e. from speaker to headphones, events are always emitted!
+  volumeChange: EventTypeWithValue; //triggered when volume level is changed
+  interruption: OnInterruptionEventType; //triggered when f.e. some app wants to play music when we are playing
+  routeChange: OnRouteChangeEventType; //change of output f.e. from speaker to headphones, events are always emitted!
 };
 
 type RemoteCommandEventName = keyof RemoteCommandEvents;
 type SystemEventName = keyof SystemEvents;
 type SystemEventCallback<Name extends SystemEventName> = (
-event: SystemEvents[Name]
+  event: SystemEvents[Name]
 ) => void;
-
-````
+```
 </details>
 
 
@@ -325,14 +326,14 @@ class AudioEventSubscription {
     );
   }
 }
-````
-
+```
 </details>
 
 ### `PermissionStatus`
 
 <details>
-  <summary>Type definitions</summary>
-  ```typescript type PermissionStatus = 'Undetermined' | 'Denied' | 'Granted';
-  ```
+<summary>Type definitions</summary>
+```typescript
+type PermissionStatus = 'Undetermined' | 'Denied' | 'Granted';
+```
 </details>

--- a/packages/audiodocs/docs/system/audio-manager.mdx
+++ b/packages/audiodocs/docs/system/audio-manager.mdx
@@ -6,7 +6,7 @@ import { Optional, ReadOnly, OnlyiOS } from '@site/src/components/Badges';
 
 # AudioManager
 
-The `AudioManager` is a layer of an abstraction between user and a system. 
+The `AudioManager` is a layer of an abstraction between user and a system.
 It provides a set of system-specific functions that are invoked directly in native code, by related system.
 
 ## Example
@@ -16,23 +16,22 @@ import { AudioManager } from 'react-native-audio-api';
 import { useEffect } from 'react';
 
 function App() {
-    // set AVAudioSession example options (iOS only)
-    AudioManager.setAudioSessionOptions({
-      iosCategory: 'playback',
-      iosMode: 'default',
-      iosOptions: ['allowBluetooth', 'allowAirPlay'],
-    })
+  // set AVAudioSession example options (iOS only)
+  AudioManager.setAudioSessionOptions({
+    iosCategory: 'playback',
+    iosMode: 'default',
+    iosOptions: ['allowBluetooth', 'allowAirPlay'],
+  });
 
-    // set info for track to be visible while device is locked
-    AudioManager.setLockScreenInfo({
-        title: 'Audio file',
-        artist: 'Software Mansion',
-        album: 'Audio API',
-        duration: 10,
-    });
+  // set info for track to be visible while device is locked
+  AudioManager.setLockScreenInfo({
+    title: 'Audio file',
+    artist: 'Software Mansion',
+    album: 'Audio API',
+    duration: 10,
+  });
 
   useEffect(() => {
-
     // enabling emission of events
     AudioManager.enableRemoteCommand('remotePlay', true);
     AudioManager.enableRemoteCommand('remotePause', true);
@@ -62,7 +61,6 @@ function App() {
       }
     );
 
-
     return () => {
       remotePlaySubscription?.remove();
       remotePauseSubscription?.remove();
@@ -76,9 +74,9 @@ function App() {
 
 ### `setLockScreenInfo`
 
-| Parameters | Type | Description |
-| :---: | :---: | :-----: |
-| `info` | [`LockScreenInfo`](/system/audio-manager#lockscreeninfo) | Information to be displayed on the lock screen |
+| Parameters |                           Type                           |                  Description                   |
+| :--------: | :------------------------------------------------------: | :--------------------------------------------: |
+|   `info`   | [`LockScreenInfo`](/system/audio-manager#lockscreeninfo) | Information to be displayed on the lock screen |
 
 #### Returns `undefined`
 
@@ -90,17 +88,17 @@ Resets all of the lock screen data.
 
 ### `setAudioSessionOptions` <OnlyiOS />
 
-| Parameters | Type | Description |
-| :---: | :---: | :---- |
-| options | [`SessionOptions`](/system/audio-manager#sessionoptions) | Options to be set for AVAudioSession |
+| Parameters |                           Type                           | Description                          |
+| :--------: | :------------------------------------------------------: | :----------------------------------- |
+|  options   | [`SessionOptions`](/system/audio-manager#sessionoptions) | Options to be set for AVAudioSession |
 
 #### Returns `undefined`
 
 ### `setAudioSessionActivity` <OnlyiOS />
 
-| Parameters | Type | Description |
-| :---: | :---: | :---- |
-| enabled | `boolean` | It is used to set/unset AVAudioSession activity |
+| Parameters |   Type    | Description                                     |
+| :--------: | :-------: | :---------------------------------------------- |
+|  enabled   | `boolean` | It is used to set/unset AVAudioSession activity |
 
 #### Returns promise of `boolean` type, which is resolved to `true` if invokation ended with success, `false` otherwise.
 
@@ -110,17 +108,17 @@ Resets all of the lock screen data.
 
 ### `observeAudioInterruptions`
 
-| Parameters | Type | Description |
-| :---: | :---: | :---- |
-| `enabled` | `boolean` | It is used to enable/disable observing audio interruptions |
+| Parameters |   Type    | Description                                                |
+| :--------: | :-------: | :--------------------------------------------------------- |
+| `enabled`  | `boolean` | It is used to enable/disable observing audio interruptions |
 
 #### Returns `undefined`
 
 ### `observeVolumeChanges`
 
-| Parameters | Type | Description |
-| :---: | :---: | :---- |
-| `enabled` | `boolean` | It is used to enable/disable observing volume changes |
+| Parameters |   Type    | Description                                           |
+| :--------: | :-------: | :---------------------------------------------------- |
+| `enabled`  | `boolean` | It is used to enable/disable observing volume changes |
 
 #### Returns `undefined`
 
@@ -128,10 +126,10 @@ Resets all of the lock screen data.
 
 Enables emition of some system events.
 
-| Parameters | Type | Description |
-| :---: | :---: | :---- |
-| `name` | [`RemoteCommandEventName`](/system/audio-manager#systemeventname--remotecommandeventname) | Name of an event |
-| `enabled` | `boolean` | Indicates the start or the end of event emission |
+| Parameters |                                           Type                                            | Description                                      |
+| :--------: | :---------------------------------------------------------------------------------------: | :----------------------------------------------- |
+|   `name`   | [`RemoteCommandEventName`](/system/audio-manager#systemeventname--remotecommandeventname) | Name of an event                                 |
+| `enabled`  |                                         `boolean`                                         | Indicates the start or the end of event emission |
 
 #### Returns `undefined`
 
@@ -142,14 +140,13 @@ with proper parameters.
 
 :::
 
-
 ### `addSystemEventListener`
 
 Adds callback to be invoked upon hearing an event.
 
-| Parameters | Type | Description |
-| :---: | :---: | :---- |
-| `name` | [`SystemEventName`](/system/audio-manager#systemeventname--remotecommandeventname) | Name of an event listener |
+| Parameters |                                          Type                                          | Description                                         |
+| :--------: | :------------------------------------------------------------------------------------: | :-------------------------------------------------- |
+|   `name`   |   [`SystemEventName`](/system/audio-manager#systemeventname--remotecommandeventname)   | Name of an event listener                           |
 | `callback` | [`SystemEventCallback`](/system/audio-manager#systemeventname--remotecommandeventname) | Callback that will be invoked upon hearing an event |
 
 #### Returns [`AudioEventSubscription`](/system/audio-manager#audioeventsubscription) if `enabled` is set to true, `undefined` otherwise
@@ -182,20 +179,21 @@ interface BaseLockScreenInfo {
 type MediaState = 'state_playing' | 'state_paused';
 
 interface LockScreenInfo extends BaseLockScreenInfo {
-  title?: string; //title of the track
-  artwork?: string; //uri to the artwork
-  artist?: string; //name of the artist
-  album?: string; //name of the album
-  duration?: number; //duration in seconds
-  description?: string; // android only, description of the track
-  state?: MediaState;
-  speed?: number; //playback rate
-  elapsedTime?: number; //elapsed time of an audio in seconds
+title?: string; //title of the track
+artwork?: string; //uri to the artwork
+artist?: string; //name of the artist
+album?: string; //name of the album
+duration?: number; //duration in seconds
+description?: string; // android only, description of the track
+state?: MediaState;
+speed?: number; //playback rate
+elapsedTime?: number; //elapsed time of an audio in seconds
 }
-```
+
+````
 </details>
 
-### `SessionOptions` 
+### `SessionOptions`
 
 <details>
 <summary>Type definitions</summary>
@@ -234,9 +232,9 @@ interface SessionOptions {
   iosOptions?: IOSOption[];
   iosCategory?: IOSCategory;
 }
-```
-</details>
+````
 
+</details>
 
 ### `SystemEventName` | `RemoteCommandEventName`
 
@@ -246,55 +244,56 @@ interface SessionOptions {
 interface EventEmptyType {}
 
 interface EventTypeWithValue {
-  value: number;
+value: number;
 }
 
 interface OnInterruptionEventType {
-  type: 'ended' | 'began'; //if interruption event has started or ended
-  shouldResume: boolean; //if we should resume playing after interruption
+type: 'ended' | 'began'; //if interruption event has started or ended
+shouldResume: boolean; //if we should resume playing after interruption
 }
 
 interface OnRouteChangeEventType {
-  reason:
-    | 'Unknown'
-    | 'Override'
-    | 'CategoryChange'
-    | 'WakeFromSleep'
-    | 'NewDeviceAvailable'
-    | 'OldDeviceUnavailable'
-    | 'ConfigurationChange'
-    | 'NoSuitableRouteForCategory';
+reason:
+| 'Unknown'
+| 'Override'
+| 'CategoryChange'
+| 'WakeFromSleep'
+| 'NewDeviceAvailable'
+| 'OldDeviceUnavailable'
+| 'ConfigurationChange'
+| 'NoSuitableRouteForCategory';
 }
 
 // visit https://developer.apple.com/documentation/mediaplayer/mpremotecommandcenter?language=objc
 // for further info
 interface RemoteCommandEvents {
-  remotePlay: EventEmptyType;
-  remotePause: EventEmptyType;
-  remoteStop: EventEmptyType;
-  remoteTogglePlayPause: EventEmptyType; // iOS only
-  remoteChangePlaybackRate: EventTypeWithValue;
-  remoteNextTrack: EventEmptyType;
-  remotePreviousTrack: EventEmptyType;
-  remoteSkipForward: EventTypeWithValue;
-  remoteSkipBackward: EventTypeWithValue; // iOS only
-  remoteSeekForward: EventEmptyType; // iOS only
-  remoteSeekBackward: EventEmptyType;
-  remoteChangePlaybackPosition: EventTypeWithValue;
+remotePlay: EventEmptyType;
+remotePause: EventEmptyType;
+remoteStop: EventEmptyType;
+remoteTogglePlayPause: EventEmptyType; // iOS only
+remoteChangePlaybackRate: EventTypeWithValue;
+remoteNextTrack: EventEmptyType;
+remotePreviousTrack: EventEmptyType;
+remoteSkipForward: EventTypeWithValue;
+remoteSkipBackward: EventTypeWithValue; // iOS only
+remoteSeekForward: EventEmptyType; // iOS only
+remoteSeekBackward: EventEmptyType;
+remoteChangePlaybackPosition: EventTypeWithValue;
 }
 
 type SystemEvents = RemoteCommandEvents & {
-  volumeChange: EventTypeWithValue; //triggered when volume level is changed
-  interruption: OnInterruptionEventType; //triggered when f.e. some app wants to play music when we are playing
-  routeChange: OnRouteChangeEventType; //change of output f.e. from speaker to headphones, events are always emitted!
+volumeChange: EventTypeWithValue; //triggered when volume level is changed
+interruption: OnInterruptionEventType; //triggered when f.e. some app wants to play music when we are playing
+routeChange: OnRouteChangeEventType; //change of output f.e. from speaker to headphones, events are always emitted!
 };
 
 type RemoteCommandEventName = keyof RemoteCommandEvents;
 type SystemEventName = keyof SystemEvents;
 type SystemEventCallback<Name extends SystemEventName> = (
-  event: SystemEvents[Name]
+event: SystemEvents[Name]
 ) => void;
-```
+
+````
 </details>
 
 
@@ -326,14 +325,14 @@ class AudioEventSubscription {
     );
   }
 }
-```
+````
+
 </details>
 
 ### `PermissionStatus`
 
 <details>
-<summary>Type definitions</summary>
-```typescript
-type PermissionStatus = 'Undetermined' | 'Denied' | 'Granted';
-```
+  <summary>Type definitions</summary>
+  ```typescript type PermissionStatus = 'Undetermined' | 'Denied' | 'Granted';
+  ```
 </details>

--- a/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
@@ -97,9 +97,9 @@ RCT_EXPORT_METHOD(
   resolve(@"false");
 }
 
-RCT_EXPORT_METHOD(setAudioSessionOptions : (NSString *)category mode : (NSString *)mode options : (NSArray *)options)
+RCT_EXPORT_METHOD(setAudioSessionOptions : (NSString *)category mode : (NSString *)mode options : (NSArray *)options allowHaptics : (BOOL)allowHaptics)
 {
-  [self.audioSessionManager setAudioSessionOptions:category mode:mode options:options];
+  [self.audioSessionManager setAudioSessionOptions:category mode:mode options:options allowHaptics:allowHaptics];
 }
 
 RCT_EXPORT_METHOD(setLockScreenInfo : (NSDictionary *)info)

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
@@ -20,7 +20,7 @@
 - (bool)configureAudioSession;
 
 - (NSNumber *)getDevicePreferredSampleRate;
-- (void)setAudioSessionOptions:(NSString *)category mode:(NSString *)mode options:(NSArray *)options;
+- (void)setAudioSessionOptions:(NSString *)category mode:(NSString *)mode options:(NSArray *)options allowHaptics:(BOOL)allowHaptics;
 - (bool)setActive:(bool)active;
 - (void)requestRecordingPermissions:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)checkRecordingPermissions:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
@@ -13,6 +13,7 @@
 @property (nonatomic, assign) AVAudioSessionMode sessionMode;
 @property (nonatomic, assign) AVAudioSessionCategory sessionCategory;
 @property (nonatomic, assign) AVAudioSessionCategoryOptions sessionOptions;
+@property (nonatomic, assign) bool allowHapticsAndSystemSoundsDuringRecording;
 
 - (instancetype)init;
 - (void)cleanup;

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
@@ -30,12 +30,12 @@
   return [NSNumber numberWithFloat:[self.audioSession sampleRate]];
 }
 
-- (void)setAudioSessionOptions:(NSString *)category mode:(NSString *)mode options:(NSArray *)options
+- (void)setAudioSessionOptions:(NSString *)category mode:(NSString *)mode options:(NSArray *)options allowHaptics:(BOOL)allowHaptics
 {
   AVAudioSessionCategory sessionCategory = self.sessionCategory;
   AVAudioSessionMode sessionMode = self.sessionMode;
   AVAudioSessionCategoryOptions sessionOptions = 0;
-  bool allowHapticsAndSystemSoundsDuringRecording = false;
+  bool allowHapticsAndSystemSoundsDuringRecording = allowHaptics;
 
   if ([category isEqualToString:@"record"]) {
     sessionCategory = AVAudioSessionCategoryRecord;
@@ -102,10 +102,6 @@
 
     if ([option isEqualToString:@"interruptSpokenAudioAndMixWithOthers"]) {
       sessionOptions |= AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers;
-    }
-
-    if ([option isEqualToString:@"allowHapticsAndSystemSoundsDuringRecording"]) {
-      allowHapticsAndSystemSoundsDuringRecording = true;
     }
   }
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
@@ -10,6 +10,7 @@
     self.sessionCategory = AVAudioSessionCategoryPlayback;
     self.sessionMode = AVAudioSessionModeDefault;
     self.sessionOptions = 0;
+    self.allowHapticsAndSystemSoundsDuringRecording = false;
     self.hasDirtySettings = true;
     self.isActive = false;
   }
@@ -34,6 +35,7 @@
   AVAudioSessionCategory sessionCategory = self.sessionCategory;
   AVAudioSessionMode sessionMode = self.sessionMode;
   AVAudioSessionCategoryOptions sessionOptions = 0;
+  bool allowHapticsAndSystemSoundsDuringRecording = false;
 
   if ([category isEqualToString:@"record"]) {
     sessionCategory = AVAudioSessionCategoryRecord;
@@ -101,6 +103,10 @@
     if ([option isEqualToString:@"interruptSpokenAudioAndMixWithOthers"]) {
       sessionOptions |= AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers;
     }
+
+    if ([option isEqualToString:@"allowHapticsAndSystemSoundsDuringRecording"]) {
+      allowHapticsAndSystemSoundsDuringRecording = true;
+    }
   }
 
   if (self.sessionCategory != sessionCategory) {
@@ -116,6 +122,11 @@
   if (self.sessionOptions != sessionOptions) {
     self.hasDirtySettings = true;
     self.sessionOptions = sessionOptions;
+  }
+
+  if (self.allowHapticsAndSystemSoundsDuringRecording != allowHapticsAndSystemSoundsDuringRecording) {
+    self.hasDirtySettings = true;
+    self.allowHapticsAndSystemSoundsDuringRecording = allowHapticsAndSystemSoundsDuringRecording;
   }
 
   if (self.isActive) {
@@ -157,10 +168,11 @@
   }
 
   NSLog(
-      @"[AudioSessionManager] configureAudioSession, category: %@, mode: %@, options: %lu",
+      @"[AudioSessionManager] configureAudioSession, category: %@, mode: %@, options: %lu, allowHaptics: %@",
       self.sessionCategory,
       self.sessionMode,
-      (unsigned long)self.sessionOptions);
+      (unsigned long)self.sessionOptions,
+      self.allowHapticsAndSystemSoundsDuringRecording ? @"YES" : @"NO");
 
   NSError *error = nil;
 
@@ -169,6 +181,14 @@
   if (error != nil) {
     NSLog(@"Error while configuring audio session: %@", [error debugDescription]);
     return false;
+  }
+
+  if (@available(iOS 13.0, *)) {
+    [self.audioSession setAllowHapticsAndSystemSoundsDuringRecording:self.allowHapticsAndSystemSoundsDuringRecording error:&error];
+    
+    if (error != nil) {
+      NSLog(@"Error while setting allowHapticsAndSystemSoundsDuringRecording: %@", [error debugDescription]);
+    }
   }
 
   self.hasDirtySettings = false;

--- a/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
+++ b/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
@@ -12,7 +12,8 @@ interface Spec extends TurboModule {
   setAudioSessionOptions(
     category: string,
     mode: string,
-    options: Array<string>
+    options: Array<string>,
+    allowHaptics: boolean
   ): void;
 
   // Lock Screen Info

--- a/packages/react-native-audio-api/src/system/AudioManager.ts
+++ b/packages/react-native-audio-api/src/system/AudioManager.ts
@@ -35,7 +35,8 @@ class AudioManager {
     NativeAudioAPIModule!.setAudioSessionOptions(
       options.iosCategory ?? '',
       options.iosMode ?? '',
-      options.iosOptions ?? []
+      options.iosOptions ?? [],
+      options.iosAllowHaptics ?? false
     );
   }
 

--- a/packages/react-native-audio-api/src/system/types.ts
+++ b/packages/react-native-audio-api/src/system/types.ts
@@ -25,13 +25,13 @@ export type IOSOption =
   | 'defaultToSpeaker'
   | 'allowBluetoothA2DP'
   | 'overrideMutedMicrophoneInterruption'
-  | 'interruptSpokenAudioAndMixWithOthers'
-  | 'allowHapticsAndSystemSoundsDuringRecording';
+  | 'interruptSpokenAudioAndMixWithOthers';
 
 export interface SessionOptions {
   iosMode?: IOSMode;
   iosOptions?: IOSOption[];
   iosCategory?: IOSCategory;
+  iosAllowHaptics?: boolean;
 }
 
 export type MediaState = 'state_playing' | 'state_paused';

--- a/packages/react-native-audio-api/src/system/types.ts
+++ b/packages/react-native-audio-api/src/system/types.ts
@@ -25,7 +25,8 @@ export type IOSOption =
   | 'defaultToSpeaker'
   | 'allowBluetoothA2DP'
   | 'overrideMutedMicrophoneInterruption'
-  | 'interruptSpokenAudioAndMixWithOthers';
+  | 'interruptSpokenAudioAndMixWithOthers'
+  | 'allowHapticsAndSystemSoundsDuringRecording';
 
 export interface SessionOptions {
   iosMode?: IOSMode;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

- Added support for the allowHapticsAndSystemSoundsDuringRecording option in AudioSessionManager for iOS (iOS 13+).
- Updates types and config on both Objective-C and TypeScript sides.
- Now possible to enable haptic and system sounds while recording audio sessions on iOS.


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
