### PR TITLE
fix: fix loop start being ahead of current progress

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
@@ -264,16 +264,20 @@ void AudioBufferSourceNode::processWithoutInterpolation(
     float playbackRate) {
   size_t direction = playbackRate < 0.0f ? -1 : 1;
 
-  auto readIndex = static_cast<size_t>(vReadIndex_);
   size_t writeIndex = startOffset;
+  size_t framesLeft = offsetLength;
+
+  auto readIndex = static_cast<size_t>(vReadIndex_);
 
   auto frameStart = static_cast<size_t>(getVirtualStartFrame());
   auto frameEnd = static_cast<size_t>(getVirtualEndFrame());
   size_t frameDelta = frameEnd - frameStart;
 
-  size_t framesLeft = offsetLength;
+  assert(frameStart <= frameEnd);
 
-  if (loop_ && (readIndex >= frameEnd || readIndex < frameStart)) {
+  if (readIndex < frameStart) {
+    readIndex = frameStart;
+  } else if (readIndex >= frameEnd && loop_) {
     readIndex = frameStart + (readIndex - frameStart) % frameDelta;
   }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #496 

## Introduced changes

<!-- A brief description of the changes -->
With current implementation of:
https://github.com/software-mansion/react-native-audio-api/blob/8ab72132881d8752ada3e8b5a7d60976b8aec2f5/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp#L276C1-L278C4

If audio is playing at second x, say 5, and the audio's `loopStart` was set to something more than x, say 9 while looping then the condition satisfies because `_loop = true` and `readIndex < frameStart` which then assigns `readIndex` to `frameStart + (readIndex - frameStart) % frameDelta` and `readIndex - frameStart` underflows because it produces a negative number but they are size_t(unsigned) and getting the modulus (%) with frameDelta produces an extra offset that is being added to `frameStart`, but in my opinion it makes sense that when `readIndex < frameStart` then `readIndex` should just be assigned to `frameStart` which fixes my example in the issue.

Note: I dont have a lot of context about the library so I am not sure if this has any consequences

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
