### PR TITLE
Refactor/audio buffer base source node

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,12 @@
 
 Closes #
 
+## ⚠️ Breaking changes ⚠️
+
+<!-- A brief description of the breaking changes -->
+
+-
+
 ## Introduced changes
 
 <!-- A brief description of the changes -->

--- a/apps/common-app/src/examples/AudioFile/AudioFile.tsx
+++ b/apps/common-app/src/examples/AudioFile/AudioFile.tsx
@@ -89,6 +89,7 @@ const AudioFile: FC = () => {
       remoteSkipBackwardSubscription?.remove();
       interruptionSubscription?.remove();
       AudioManager.resetLockScreenInfo();
+      AudioPlayer.reset();
     };
   }, [fetchAudioBuffer]);
 

--- a/apps/common-app/src/examples/AudioFile/AudioPlayer.ts
+++ b/apps/common-app/src/examples/AudioFile/AudioPlayer.ts
@@ -41,14 +41,16 @@ class AudioPlayer {
     });
     this.sourceNode.buffer = this.audioBuffer;
     this.sourceNode.playbackRate.value = this.playbackRate;
-    this.sourceNode.onended = (event) => {
-      this.offset = event.value;
-    };
+
     this.sourceNode.connect(this.audioContext.destination);
     if (this.seekOffset !== 0) {
       this.offset = Math.max(this.seekOffset + this.offset, 0);
       this.seekOffset = 0;
     }
+    this.sourceNode.onPositionChanged = (event) => {
+      this.offset = event.value;
+    };
+
     this.sourceNode.start(this.audioContext.currentTime, this.offset);
 
     AudioManager.setLockScreenInfo({
@@ -104,11 +106,12 @@ class AudioPlayer {
 
   reset = () => {
     this.audioBuffer = null;
-    this.sourceNode?.disconnect();
+    this.sourceNode?.stop(this.audioContext.currentTime);
     this.sourceNode = null;
     this.offset = 0;
     this.seekOffset = 0;
     this.playbackRate = 1;
+    this.isPlaying = false;
   };
 }
 

--- a/apps/common-app/src/examples/DrumMachine/DrumMachine.tsx
+++ b/apps/common-app/src/examples/DrumMachine/DrumMachine.tsx
@@ -136,7 +136,7 @@ const DrumMachine: React.FC = () => {
           label="BPM"
           step={1}
           min={24}
-          max={2000}
+          max={1000}
           value={bpm}
           onValueChange={setBpm}
         />

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferBaseSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferBaseSourceNodeHostObject.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <audioapi/core/sources/AudioBufferBaseSourceNode.h>
+#include <audioapi/HostObjects/AudioParamHostObject.h>
+#include <audioapi/HostObjects/AudioScheduledSourceNodeHostObject.h>
+
+#include <memory>
+#include <vector>
+
+namespace audioapi {
+using namespace facebook;
+
+class AudioBufferBaseSourceNodeHostObject
+        : public AudioScheduledSourceNodeHostObject {
+ public:
+    explicit AudioBufferBaseSourceNodeHostObject(
+            const std::shared_ptr<AudioBufferBaseSourceNode> &node)
+            : AudioScheduledSourceNodeHostObject(node) {
+        addGetters(
+                JSI_EXPORT_PROPERTY_GETTER(AudioBufferBaseSourceNodeHostObject, detune),
+                JSI_EXPORT_PROPERTY_GETTER(AudioBufferBaseSourceNodeHostObject, playbackRate));
+
+        addSetters(
+                JSI_EXPORT_PROPERTY_SETTER(AudioBufferBaseSourceNodeHostObject, onPositionChanged),
+                JSI_EXPORT_PROPERTY_SETTER(AudioBufferBaseSourceNodeHostObject, onPositionChangedInterval));
+    }
+
+    JSI_PROPERTY_GETTER(detune) {
+        auto sourceNode =
+                std::static_pointer_cast<AudioBufferBaseSourceNode>(node_);
+        auto detune = sourceNode->getDetuneParam();
+        auto detuneHostObject = std::make_shared<AudioParamHostObject>(detune);
+        return jsi::Object::createFromHostObject(runtime, detuneHostObject);
+    }
+
+    JSI_PROPERTY_GETTER(playbackRate) {
+        auto sourceNode =
+                std::static_pointer_cast<AudioBufferBaseSourceNode>(node_);
+        auto playbackRate = sourceNode->getPlaybackRateParam();
+        auto playbackRateHostObject =
+                std::make_shared<AudioParamHostObject>(playbackRate);
+        return jsi::Object::createFromHostObject(runtime, playbackRateHostObject);
+    }
+
+    JSI_PROPERTY_SETTER(onPositionChanged) {
+        auto sourceNode =
+                std::static_pointer_cast<AudioBufferBaseSourceNode>(node_);
+
+        sourceNode->setOnPositionChangedCallbackId(std::stoull(value.getString(runtime).utf8(runtime)));
+    }
+
+    JSI_PROPERTY_SETTER(onPositionChangedInterval) {
+        auto sourceNode =
+                std::static_pointer_cast<AudioBufferBaseSourceNode>(node_);
+
+        sourceNode->setOnPositionChangedInterval(static_cast<int>(value.getNumber()));
+    }
+};
+
+} // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferQueueSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferQueueSourceNodeHostObject.h
@@ -25,11 +25,8 @@ class AudioBufferQueueSourceNodeHostObject
                 JSI_EXPORT_PROPERTY_SETTER(AudioBufferQueueSourceNodeHostObject, onPositionChanged),
                 JSI_EXPORT_PROPERTY_SETTER(AudioBufferQueueSourceNodeHostObject, onPositionChangedInterval));
 
-        // start method is overridden in this class
-        functions_->erase("start");
 
         addFunctions(
-                JSI_EXPORT_FUNCTION(AudioBufferQueueSourceNodeHostObject, start),
                 JSI_EXPORT_FUNCTION(AudioBufferQueueSourceNodeHostObject, enqueueBuffer),
                 JSI_EXPORT_FUNCTION(AudioBufferQueueSourceNodeHostObject, pause));
     }
@@ -62,24 +59,7 @@ class AudioBufferQueueSourceNodeHostObject
         auto audioBufferQueueSourceNode =
                 std::static_pointer_cast<AudioBufferQueueSourceNode>(node_);
 
-        audioBufferQueueSourceNode->setOnPositionChangedInterval(value.getNumber());
-    }
-
-    JSI_HOST_FUNCTION(start) {
-        auto when = args[0].getNumber();
-
-        auto audioBufferQueueSourceNode =
-                std::static_pointer_cast<AudioBufferQueueSourceNode>(node_);
-
-        double offset = -1.0;
-
-        if (args[1].isNumber()) {
-            offset = args[1].asNumber();
-        }
-
-        audioBufferQueueSourceNode->start(when, offset);
-
-        return jsi::Value::undefined();
+        audioBufferQueueSourceNode->setOnPositionChangedInterval(static_cast<int>(value.getNumber()));
     }
 
     JSI_HOST_FUNCTION(pause) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferQueueSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferQueueSourceNodeHostObject.h
@@ -36,10 +36,9 @@ class AudioBufferQueueSourceNodeHostObject
 
         auto audioBufferHostObject =
                 args[0].getObject(runtime).asHostObject<AudioBufferHostObject>(runtime);
-        int bufferId = args[1].asNumber();
-        auto isLastBuffer = args[2].asBool();
+        auto isLastBuffer = args[1].asBool();
 
-        audioBufferQueueSourceNode->enqueueBuffer(audioBufferHostObject->audioBuffer_, bufferId, isLastBuffer);
+        audioBufferQueueSourceNode->enqueueBuffer(audioBufferHostObject->audioBuffer_, isLastBuffer);
 
         return jsi::Value::undefined();
     }

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferQueueSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferQueueSourceNodeHostObject.h
@@ -2,8 +2,7 @@
 
 #include <audioapi/HostObjects/AudioBufferHostObject.h>
 #include <audioapi/core/sources/AudioBufferQueueSourceNode.h>
-#include <audioapi/HostObjects/AudioParamHostObject.h>
-#include <audioapi/HostObjects/AudioScheduledSourceNodeHostObject.h>
+#include <audioapi/HostObjects/AudioBufferBaseSourceNodeHostObject.h>
 
 #include <memory>
 #include <vector>
@@ -12,54 +11,14 @@ namespace audioapi {
 using namespace facebook;
 
 class AudioBufferQueueSourceNodeHostObject
-            : public AudioScheduledSourceNodeHostObject {
+            : public AudioBufferBaseSourceNodeHostObject {
  public:
     explicit AudioBufferQueueSourceNodeHostObject(
             const std::shared_ptr<AudioBufferQueueSourceNode> &node)
-            : AudioScheduledSourceNodeHostObject(node) {
-        addGetters(
-                JSI_EXPORT_PROPERTY_GETTER(AudioBufferQueueSourceNodeHostObject, detune),
-                JSI_EXPORT_PROPERTY_GETTER(AudioBufferQueueSourceNodeHostObject, playbackRate));
-
-        addSetters(
-                JSI_EXPORT_PROPERTY_SETTER(AudioBufferQueueSourceNodeHostObject, onPositionChanged),
-                JSI_EXPORT_PROPERTY_SETTER(AudioBufferQueueSourceNodeHostObject, onPositionChangedInterval));
-
-
+            : AudioBufferBaseSourceNodeHostObject(node) {
         addFunctions(
                 JSI_EXPORT_FUNCTION(AudioBufferQueueSourceNodeHostObject, enqueueBuffer),
                 JSI_EXPORT_FUNCTION(AudioBufferQueueSourceNodeHostObject, pause));
-    }
-
-    JSI_PROPERTY_GETTER(detune) {
-        auto audioBufferSourceNode =
-                std::static_pointer_cast<AudioBufferQueueSourceNode>(node_);
-        auto detune = audioBufferSourceNode->getDetuneParam();
-        auto detuneHostObject = std::make_shared<AudioParamHostObject>(detune);
-        return jsi::Object::createFromHostObject(runtime, detuneHostObject);
-    }
-
-    JSI_PROPERTY_GETTER(playbackRate) {
-        auto audioBufferSourceNode =
-                std::static_pointer_cast<AudioBufferQueueSourceNode>(node_);
-        auto playbackRate = audioBufferSourceNode->getPlaybackRateParam();
-        auto playbackRateHostObject =
-                std::make_shared<AudioParamHostObject>(playbackRate);
-        return jsi::Object::createFromHostObject(runtime, playbackRateHostObject);
-    }
-
-    JSI_PROPERTY_SETTER(onPositionChanged) {
-        auto audioBufferQueueSourceNode =
-                std::static_pointer_cast<AudioBufferQueueSourceNode>(node_);
-
-        audioBufferQueueSourceNode->setOnPositionChangedCallbackId(std::stoull(value.getString(runtime).utf8(runtime)));
-    }
-
-    JSI_PROPERTY_SETTER(onPositionChangedInterval) {
-        auto audioBufferQueueSourceNode =
-                std::static_pointer_cast<AudioBufferQueueSourceNode>(node_);
-
-        audioBufferQueueSourceNode->setOnPositionChangedInterval(static_cast<int>(value.getNumber()));
     }
 
     JSI_HOST_FUNCTION(pause) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferSourceNodeHostObject.h
@@ -2,8 +2,7 @@
 
 #include <audioapi/HostObjects/AudioBufferHostObject.h>
 #include <audioapi/core/sources/AudioBufferSourceNode.h>
-#include <audioapi/HostObjects/AudioParamHostObject.h>
-#include <audioapi/HostObjects/AudioScheduledSourceNodeHostObject.h>
+#include <audioapi/HostObjects/AudioBufferBaseSourceNodeHostObject.h>
 
 #include <memory>
 #include <vector>
@@ -12,28 +11,24 @@ namespace audioapi {
 using namespace facebook;
 
 class AudioBufferSourceNodeHostObject
-    : public AudioScheduledSourceNodeHostObject {
+    : public AudioBufferBaseSourceNodeHostObject {
  public:
   explicit AudioBufferSourceNodeHostObject(
       const std::shared_ptr<AudioBufferSourceNode> &node)
-      : AudioScheduledSourceNodeHostObject(node) {
+      : AudioBufferBaseSourceNodeHostObject(node) {
     addGetters(
         JSI_EXPORT_PROPERTY_GETTER(AudioBufferSourceNodeHostObject, loop),
         JSI_EXPORT_PROPERTY_GETTER(AudioBufferSourceNodeHostObject, loopSkip),
         JSI_EXPORT_PROPERTY_GETTER(AudioBufferSourceNodeHostObject, buffer),
         JSI_EXPORT_PROPERTY_GETTER(AudioBufferSourceNodeHostObject, loopStart),
-        JSI_EXPORT_PROPERTY_GETTER(AudioBufferSourceNodeHostObject, loopEnd),
-        JSI_EXPORT_PROPERTY_GETTER(AudioBufferSourceNodeHostObject, detune),
-        JSI_EXPORT_PROPERTY_GETTER(AudioBufferSourceNodeHostObject, playbackRate));
+        JSI_EXPORT_PROPERTY_GETTER(AudioBufferSourceNodeHostObject, loopEnd));
 
     addSetters(
         JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, loop),
         JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, loopSkip),
         JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, buffer),
         JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, loopStart),
-        JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, loopEnd),
-        JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, onPositionChanged),
-        JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, onPositionChangedInterval));
+        JSI_EXPORT_PROPERTY_SETTER(AudioBufferSourceNodeHostObject, loopEnd));
 
     // start method is overridden in this class
     functions_->erase("start");
@@ -83,23 +78,6 @@ class AudioBufferSourceNodeHostObject
     return {loopEnd};
   }
 
-  JSI_PROPERTY_GETTER(detune) {
-    auto audioBufferSourceNode =
-        std::static_pointer_cast<AudioBufferSourceNode>(node_);
-    auto detune = audioBufferSourceNode->getDetuneParam();
-    auto detuneHostObject = std::make_shared<AudioParamHostObject>(detune);
-    return jsi::Object::createFromHostObject(runtime, detuneHostObject);
-  }
-
-  JSI_PROPERTY_GETTER(playbackRate) {
-    auto audioBufferSourceNode =
-        std::static_pointer_cast<AudioBufferSourceNode>(node_);
-    auto playbackRate = audioBufferSourceNode->getPlaybackRateParam();
-    auto playbackRateHostObject =
-        std::make_shared<AudioParamHostObject>(playbackRate);
-    return jsi::Object::createFromHostObject(runtime, playbackRateHostObject);
-  }
-
   JSI_PROPERTY_SETTER(loop) {
     auto audioBufferSourceNode =
         std::static_pointer_cast<AudioBufferSourceNode>(node_);
@@ -135,20 +113,6 @@ class AudioBufferSourceNodeHostObject
     auto audioBufferSourceNode =
         std::static_pointer_cast<AudioBufferSourceNode>(node_);
     audioBufferSourceNode->setLoopEnd(value.getNumber());
-  }
-
-  JSI_PROPERTY_SETTER(onPositionChanged) {
-    auto audioBufferSourceNode =
-            std::static_pointer_cast<AudioBufferSourceNode>(node_);
-
-    audioBufferSourceNode->setOnPositionChangedCallbackId(std::stoull(value.getString(runtime).utf8(runtime)));
-  }
-
-  JSI_PROPERTY_SETTER(onPositionChangedInterval) {
-      auto audioBufferSourceNode =
-              std::static_pointer_cast<AudioBufferSourceNode>(node_);
-
-      audioBufferSourceNode->setOnPositionChangedInterval(value.getNumber());
   }
 
   JSI_HOST_FUNCTION(start) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
@@ -1,35 +1,36 @@
-#include <audioapi/core/sources/AudioBufferBaseSourceNode.h>
-#include <audioapi/events/AudioEventHandlerRegistry.h>
 #include <audioapi/core/BaseAudioContext.h>
 #include <audioapi/core/Constants.h>
+#include <audioapi/core/sources/AudioBufferBaseSourceNode.h>
+#include <audioapi/events/AudioEventHandlerRegistry.h>
 
 namespace audioapi {
 AudioBufferBaseSourceNode::AudioBufferBaseSourceNode(BaseAudioContext *context)
     : AudioScheduledSourceNode(context) {
-    onPositionChangedInterval_ = static_cast<int>(context->getSampleRate() * 0.1);
+  onPositionChangedInterval_ = static_cast<int>(context->getSampleRate() * 0.1);
 }
 
-void AudioBufferBaseSourceNode::setOnPositionChangedCallbackId(uint64_t callbackId) {
-    onPositionChangedCallbackId_ = callbackId;
+void AudioBufferBaseSourceNode::setOnPositionChangedCallbackId(
+    uint64_t callbackId) {
+  onPositionChangedCallbackId_ = callbackId;
 }
 
 void AudioBufferBaseSourceNode::setOnPositionChangedInterval(int interval) {
-    onPositionChangedInterval_ = static_cast<int>(context_->getSampleRate() *
-                                                  static_cast<float>(interval) / 1000);
+  onPositionChangedInterval_ = static_cast<int>(
+      context_->getSampleRate() * static_cast<float>(interval) / 1000);
 }
 
 void AudioBufferBaseSourceNode::sendOnPositionChangedEvent() {
-    if (onPositionChangedTime_ > onPositionChangedInterval_) {
-        std::unordered_map<std::string, EventValue> body = {
-                {"value", getCurrentPosition()}};
+  if (onPositionChangedTime_ > onPositionChangedInterval_) {
+    std::unordered_map<std::string, EventValue> body = {
+        {"value", getCurrentPosition()}};
 
-        context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
-                "positionChanged", onPositionChangedCallbackId_, body);
+    context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
+        "positionChanged", onPositionChangedCallbackId_, body);
 
-        onPositionChangedTime_ = 0;
-    }
+    onPositionChangedTime_ = 0;
+  }
 
-    onPositionChangedTime_ += RENDER_QUANTUM_SIZE;
+  onPositionChangedTime_ += RENDER_QUANTUM_SIZE;
 }
 
-}
+} // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
@@ -1,0 +1,35 @@
+#include <audioapi/core/sources/AudioBufferBaseSourceNode.h>
+#include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/core/BaseAudioContext.h>
+#include <audioapi/core/Constants.h>
+
+namespace audioapi {
+AudioBufferBaseSourceNode::AudioBufferBaseSourceNode(BaseAudioContext *context)
+    : AudioScheduledSourceNode(context) {
+    onPositionChangedInterval_ = static_cast<int>(context->getSampleRate() * 0.1);
+}
+
+void AudioBufferBaseSourceNode::setOnPositionChangedCallbackId(uint64_t callbackId) {
+    onPositionChangedCallbackId_ = callbackId;
+}
+
+void AudioBufferBaseSourceNode::setOnPositionChangedInterval(int interval) {
+    onPositionChangedInterval_ = static_cast<int>(context_->getSampleRate() *
+                                                  static_cast<float>(interval) / 1000);
+}
+
+void AudioBufferBaseSourceNode::sendOnPositionChangedEvent() {
+    if (onPositionChangedTime_ > onPositionChangedInterval_) {
+        std::unordered_map<std::string, EventValue> body = {
+                {"value", getCurrentPosition()}};
+
+        context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
+                "positionChanged", onPositionChangedCallbackId_, body);
+
+        onPositionChangedTime_ = 0;
+    }
+
+    onPositionChangedTime_ += RENDER_QUANTUM_SIZE;
+}
+
+}

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
@@ -2,11 +2,33 @@
 #include <audioapi/core/Constants.h>
 #include <audioapi/core/sources/AudioBufferBaseSourceNode.h>
 #include <audioapi/events/AudioEventHandlerRegistry.h>
+#include <audioapi/utils/AudioArray.h>
+#include <audioapi/utils/AudioBus.h>
+#include <audioapi/core/AudioParam.h>
 
 namespace audioapi {
 AudioBufferBaseSourceNode::AudioBufferBaseSourceNode(BaseAudioContext *context)
-    : AudioScheduledSourceNode(context) {
+    : AudioScheduledSourceNode(context), vReadIndex_(0.0) {
   onPositionChangedInterval_ = static_cast<int>(context->getSampleRate() * 0.1);
+
+  detuneParam_ = std::make_shared<AudioParam>(
+        0.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
+  playbackRateParam_ = std::make_shared<AudioParam>(
+        1.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
+
+  playbackRateBus_ = std::make_shared<AudioBus>(
+        RENDER_QUANTUM_SIZE * 3, channelCount_, context_->getSampleRate());
+
+  stretch_ = std::make_shared<signalsmith::stretch::SignalsmithStretch<float>>();
+}
+
+std::shared_ptr<AudioParam> AudioBufferBaseSourceNode::getDetuneParam() const {
+  return detuneParam_;
+}
+
+std::shared_ptr<AudioParam> AudioBufferBaseSourceNode::getPlaybackRateParam()
+    const {
+  return playbackRateParam_;
 }
 
 void AudioBufferBaseSourceNode::setOnPositionChangedCallbackId(
@@ -17,6 +39,10 @@ void AudioBufferBaseSourceNode::setOnPositionChangedCallbackId(
 void AudioBufferBaseSourceNode::setOnPositionChangedInterval(int interval) {
   onPositionChangedInterval_ = static_cast<int>(
       context_->getSampleRate() * static_cast<float>(interval) / 1000);
+}
+
+std::mutex &AudioBufferBaseSourceNode::getBufferLock() {
+  return bufferLock_;
 }
 
 void AudioBufferBaseSourceNode::sendOnPositionChangedEvent() {
@@ -31,6 +57,45 @@ void AudioBufferBaseSourceNode::sendOnPositionChangedEvent() {
   }
 
   onPositionChangedTime_ += RENDER_QUANTUM_SIZE;
+}
+
+void AudioBufferBaseSourceNode::processWithPitchCorrection(
+        const std::shared_ptr<AudioBus> &processingBus, int framesToProcess) {
+    size_t startOffset = 0;
+    size_t offsetLength = 0;
+
+    auto time = context_->getCurrentTime();
+    auto playbackRate = std::clamp(
+            playbackRateParam_->processKRateParam(framesToProcess, time), 0.0f, 3.0f);
+    auto detune = std::clamp(
+            detuneParam_->processKRateParam(framesToProcess, time) / 100.0f,
+            -12.0f,
+            12.0f);
+
+    playbackRateBus_->zero();
+
+    auto framesNeededToStretch =
+            static_cast<int>(playbackRate * static_cast<float>(framesToProcess));
+
+    updatePlaybackInfo(
+            playbackRateBus_, framesNeededToStretch, startOffset, offsetLength);
+
+    if (playbackRate == 0.0f || (!isPlaying() && !isStopScheduled())) {
+        processingBus->zero();
+        return;
+    }
+
+    processWithoutInterpolation(playbackRateBus_, startOffset, offsetLength, playbackRate);
+
+    stretch_->process(
+            playbackRateBus_.get()[0],
+            framesNeededToStretch,
+            processingBus.get()[0],
+            framesToProcess);
+
+    if (detune != 0.0f) {
+        stretch_->setTransposeSemitones(detune);
+    }
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
@@ -1,10 +1,10 @@
+#include <audioapi/core/AudioParam.h>
 #include <audioapi/core/BaseAudioContext.h>
 #include <audioapi/core/Constants.h>
 #include <audioapi/core/sources/AudioBufferBaseSourceNode.h>
 #include <audioapi/events/AudioEventHandlerRegistry.h>
 #include <audioapi/utils/AudioArray.h>
 #include <audioapi/utils/AudioBus.h>
-#include <audioapi/core/AudioParam.h>
 
 namespace audioapi {
 AudioBufferBaseSourceNode::AudioBufferBaseSourceNode(BaseAudioContext *context)
@@ -12,14 +12,15 @@ AudioBufferBaseSourceNode::AudioBufferBaseSourceNode(BaseAudioContext *context)
   onPositionChangedInterval_ = static_cast<int>(context->getSampleRate() * 0.1);
 
   detuneParam_ = std::make_shared<AudioParam>(
-        0.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
+      0.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
   playbackRateParam_ = std::make_shared<AudioParam>(
-        1.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
+      1.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
 
   playbackRateBus_ = std::make_shared<AudioBus>(
-        RENDER_QUANTUM_SIZE * 3, channelCount_, context_->getSampleRate());
+      RENDER_QUANTUM_SIZE * 3, channelCount_, context_->getSampleRate());
 
-  stretch_ = std::make_shared<signalsmith::stretch::SignalsmithStretch<float>>();
+  stretch_ =
+      std::make_shared<signalsmith::stretch::SignalsmithStretch<float>>();
 }
 
 std::shared_ptr<AudioParam> AudioBufferBaseSourceNode::getDetuneParam() const {
@@ -60,42 +61,44 @@ void AudioBufferBaseSourceNode::sendOnPositionChangedEvent() {
 }
 
 void AudioBufferBaseSourceNode::processWithPitchCorrection(
-        const std::shared_ptr<AudioBus> &processingBus, int framesToProcess) {
-    size_t startOffset = 0;
-    size_t offsetLength = 0;
+    const std::shared_ptr<AudioBus> &processingBus,
+    int framesToProcess) {
+  size_t startOffset = 0;
+  size_t offsetLength = 0;
 
-    auto time = context_->getCurrentTime();
-    auto playbackRate = std::clamp(
-            playbackRateParam_->processKRateParam(framesToProcess, time), 0.0f, 3.0f);
-    auto detune = std::clamp(
-            detuneParam_->processKRateParam(framesToProcess, time) / 100.0f,
-            -12.0f,
-            12.0f);
+  auto time = context_->getCurrentTime();
+  auto playbackRate = std::clamp(
+      playbackRateParam_->processKRateParam(framesToProcess, time), 0.0f, 3.0f);
+  auto detune = std::clamp(
+      detuneParam_->processKRateParam(framesToProcess, time) / 100.0f,
+      -12.0f,
+      12.0f);
 
-    playbackRateBus_->zero();
+  playbackRateBus_->zero();
 
-    auto framesNeededToStretch =
-            static_cast<int>(playbackRate * static_cast<float>(framesToProcess));
+  auto framesNeededToStretch =
+      static_cast<int>(playbackRate * static_cast<float>(framesToProcess));
 
-    updatePlaybackInfo(
-            playbackRateBus_, framesNeededToStretch, startOffset, offsetLength);
+  updatePlaybackInfo(
+      playbackRateBus_, framesNeededToStretch, startOffset, offsetLength);
 
-    if (playbackRate == 0.0f || (!isPlaying() && !isStopScheduled())) {
-        processingBus->zero();
-        return;
-    }
+  if (playbackRate == 0.0f || (!isPlaying() && !isStopScheduled())) {
+    processingBus->zero();
+    return;
+  }
 
-    processWithoutInterpolation(playbackRateBus_, startOffset, offsetLength, playbackRate);
+  processWithoutInterpolation(
+      playbackRateBus_, startOffset, offsetLength, playbackRate);
 
-    stretch_->process(
-            playbackRateBus_.get()[0],
-            framesNeededToStretch,
-            processingBus.get()[0],
-            framesToProcess);
+  stretch_->process(
+      playbackRateBus_.get()[0],
+      framesNeededToStretch,
+      processingBus.get()[0],
+      framesToProcess);
 
-    if (detune != 0.0f) {
-        stretch_->setTransposeSemitones(detune);
-    }
+  if (detune != 0.0f) {
+    stretch_->setTransposeSemitones(detune);
+  }
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.h
@@ -1,23 +1,54 @@
 #pragma once
 
 #include <audioapi/core/sources/AudioScheduledSourceNode.h>
+#include <audioapi/libs/signalsmith-stretch/signalsmith-stretch.h>
+
+#include <memory>
 
 namespace audioapi {
+
+class AudioBus;
+class AudioParam;
 
 class AudioBufferBaseSourceNode : public AudioScheduledSourceNode {
  public:
   explicit AudioBufferBaseSourceNode(BaseAudioContext *context);
 
+    [[nodiscard]] std::shared_ptr<AudioParam> getDetuneParam() const;
+    [[nodiscard]] std::shared_ptr<AudioParam> getPlaybackRateParam() const;
+
     void setOnPositionChangedCallbackId(uint64_t callbackId);
     void setOnPositionChangedInterval(int interval);
 
  protected:
+    std::mutex bufferLock_;
+
+    // pitch correction
+    std::shared_ptr<signalsmith::stretch::SignalsmithStretch<float>> stretch_;
+    std::shared_ptr<AudioBus> playbackRateBus_;
+
+    // k-rate params
+    std::shared_ptr<AudioParam> detuneParam_;
+    std::shared_ptr<AudioParam> playbackRateParam_;
+
+    // internal helper
+    double vReadIndex_;
+
     uint64_t onPositionChangedCallbackId_ = 0;
     int onPositionChangedInterval_;
     int onPositionChangedTime_ = 0;
 
-    void sendOnPositionChangedEvent();
+    std::mutex &getBufferLock();
     virtual double getCurrentPosition() const = 0;
+
+    void sendOnPositionChangedEvent();
+    void processWithPitchCorrection(const std::shared_ptr<AudioBus> &processingBus,
+                                    int framesToProcess);
+    virtual void processWithoutInterpolation(
+            const std::shared_ptr<AudioBus>& processingBus,
+            size_t startOffset,
+            size_t offsetLength,
+            float playbackRate) = 0;
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <audioapi/core/sources/AudioScheduledSourceNode.h>
+
+namespace audioapi {
+
+class AudioBufferBaseSourceNode : public AudioScheduledSourceNode {
+ public:
+  explicit AudioBufferBaseSourceNode(BaseAudioContext *context);
+
+    void setOnPositionChangedCallbackId(uint64_t callbackId);
+    void setOnPositionChangedInterval(int interval);
+
+ protected:
+    uint64_t onPositionChangedCallbackId_ = 0;
+    int onPositionChangedInterval_;
+    int onPositionChangedTime_ = 0;
+
+    void sendOnPositionChangedEvent();
+    virtual double getCurrentPosition() const = 0;
+};
+
+} // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
@@ -12,22 +12,9 @@ namespace audioapi {
 
 AudioBufferQueueSourceNode::AudioBufferQueueSourceNode(
     BaseAudioContext *context)
-    : AudioBufferBaseSourceNode(context), vReadIndex_(0.0) {
+    : AudioBufferBaseSourceNode(context) {
   buffers_ = {};
-
-  detuneParam_ = std::make_shared<AudioParam>(
-      0.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
-  playbackRateParam_ = std::make_shared<AudioParam>(
-      1.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
-
-  playbackRateBus_ = std::make_shared<AudioBus>(
-      RENDER_QUANTUM_SIZE * 3, channelCount_, context_->getSampleRate());
-
-  stretch_ =
-      std::make_shared<signalsmith::stretch::SignalsmithStretch<float>>();
   stretch_->presetDefault(channelCount_, context_->getSampleRate(), true);
-
-  onPositionChangedInterval_ = static_cast<int>(context_->getSampleRate() / 10);
 
   isInitialized_ = true;
 }
@@ -36,23 +23,6 @@ AudioBufferQueueSourceNode::~AudioBufferQueueSourceNode() {
   Locker locker(getBufferLock());
 
   buffers_ = {};
-}
-
-std::shared_ptr<AudioParam> AudioBufferQueueSourceNode::getDetuneParam() const {
-  return detuneParam_;
-}
-
-std::shared_ptr<AudioParam> AudioBufferQueueSourceNode::getPlaybackRateParam()
-    const {
-  return playbackRateParam_;
-}
-
-void AudioBufferQueueSourceNode::start(double when, double offset) {
-  AudioScheduledSourceNode::start(when);
-
-  if (offset >= 0.0) {
-    vReadIndex_ = static_cast<double>(context_->getSampleRate() * offset);
-  }
 }
 
 void AudioBufferQueueSourceNode::stop(double when) {
@@ -88,10 +58,6 @@ void AudioBufferQueueSourceNode::disable() {
   buffers_ = {};
 }
 
-std::mutex &AudioBufferQueueSourceNode::getBufferLock() {
-  return bufferLock_;
-}
-
 void AudioBufferQueueSourceNode::processNode(
     const std::shared_ptr<AudioBus> &processingBus,
     int framesToProcess) {
@@ -121,50 +87,11 @@ double AudioBufferQueueSourceNode::getCurrentPosition() const {
  * Helper functions
  */
 
-void AudioBufferQueueSourceNode::processWithPitchCorrection(
-    const std::shared_ptr<AudioBus> &processingBus,
-    int framesToProcess) {
-  size_t startOffset = 0;
-  size_t offsetLength = 0;
-
-  auto time = context_->getCurrentTime();
-  auto playbackRate = std::clamp(
-      playbackRateParam_->processKRateParam(framesToProcess, time), 0.0f, 3.0f);
-  auto detune = std::clamp(
-      detuneParam_->processKRateParam(framesToProcess, time) / 100.0f,
-      -12.0f,
-      12.0f);
-
-  playbackRateBus_->zero();
-
-  auto framesNeededToStretch =
-      static_cast<int>(playbackRate * static_cast<float>(framesToProcess));
-
-  updatePlaybackInfo(
-      playbackRateBus_, framesNeededToStretch, startOffset, offsetLength);
-
-  if (playbackRate == 0.0f || (!isPlaying() && !isStopScheduled())) {
-    processingBus->zero();
-    return;
-  }
-
-  processWithoutInterpolation(playbackRateBus_, startOffset, offsetLength);
-
-  stretch_->process(
-      playbackRateBus_.get()[0],
-      framesNeededToStretch,
-      processingBus.get()[0],
-      framesToProcess);
-
-  if (detune != 0.0f) {
-    stretch_->setTransposeSemitones(detune);
-  }
-}
-
 void AudioBufferQueueSourceNode::processWithoutInterpolation(
     const std::shared_ptr<AudioBus> &processingBus,
     size_t startOffset,
-    size_t offsetLength) {
+    size_t offsetLength,
+    float playbackRate) {
   auto readIndex = static_cast<size_t>(vReadIndex_);
   size_t writeIndex = startOffset;
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
@@ -84,7 +84,7 @@ void AudioBufferQueueSourceNode::disable() {
     return;
   }
 
- AudioScheduledSourceNode::disable();
+  AudioScheduledSourceNode::disable();
   buffers_ = {};
 }
 
@@ -112,8 +112,9 @@ void AudioBufferQueueSourceNode::processNode(
 }
 
 double AudioBufferQueueSourceNode::getCurrentPosition() const {
-    return dsp::sampleFrameToTime(
-            static_cast<int>(vReadIndex_), context_->getSampleRate()) + position_;
+  return dsp::sampleFrameToTime(
+             static_cast<int>(vReadIndex_), context_->getSampleRate()) +
+      position_;
 }
 
 /**

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
@@ -20,10 +20,6 @@ class AudioBufferQueueSourceNode : public AudioBufferBaseSourceNode {
     explicit AudioBufferQueueSourceNode(BaseAudioContext *context);
     ~AudioBufferQueueSourceNode() override;
 
-    [[nodiscard]] std::shared_ptr<AudioParam> getDetuneParam() const;
-    [[nodiscard]] std::shared_ptr<AudioParam> getPlaybackRateParam() const;
-
-    void start(double when, double offset);
     void stop(double when) override;
     void pause();
 
@@ -31,24 +27,10 @@ class AudioBufferQueueSourceNode : public AudioBufferBaseSourceNode {
     void disable() override;
 
  protected:
-    std::mutex &getBufferLock();
     void processNode(const std::shared_ptr<AudioBus>& processingBus, int framesToProcess) override;
     double getCurrentPosition() const override;
 
  private:
-    std::mutex bufferLock_;
-
-    // pitch correction
-    std::shared_ptr<signalsmith::stretch::SignalsmithStretch<float>> stretch_;
-    std::shared_ptr<AudioBus> playbackRateBus_;
-
-    // k-rate params
-    std::shared_ptr<AudioParam> detuneParam_;
-    std::shared_ptr<AudioParam> playbackRateParam_;
-
-    // internal helper
-    double vReadIndex_;
-
     // User provided buffers
     std::queue<std::pair<int, std::shared_ptr<AudioBuffer>>> buffers_;
     int bufferId_ = 0;
@@ -57,13 +39,11 @@ class AudioBufferQueueSourceNode : public AudioBufferBaseSourceNode {
 
     double position_ = 0;
 
-    void processWithPitchCorrection(const std::shared_ptr<AudioBus> &processingBus,
-                                    int framesToProcess);
-
     void processWithoutInterpolation(
             const std::shared_ptr<AudioBus>& processingBus,
             size_t startOffset,
-            size_t offsetLength);
+            size_t offsetLength,
+            float playbackRate) override;
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
@@ -23,7 +23,7 @@ class AudioBufferQueueSourceNode : public AudioBufferBaseSourceNode {
     void stop(double when) override;
     void pause();
 
-    void enqueueBuffer(const std::shared_ptr<AudioBuffer> &buffer, int bufferId, bool isLastBuffer);
+    void enqueueBuffer(const std::shared_ptr<AudioBuffer> &buffer, bool isLastBuffer);
     void disable() override;
 
  protected:
@@ -32,12 +32,11 @@ class AudioBufferQueueSourceNode : public AudioBufferBaseSourceNode {
 
  private:
     // User provided buffers
-    std::queue<std::pair<int, std::shared_ptr<AudioBuffer>>> buffers_;
-    int bufferId_ = 0;
+    std::queue<std::shared_ptr<AudioBuffer>> buffers_;
     bool isLastBuffer_ = false;
     bool isPaused_ = false;
 
-    double position_ = 0;
+    double playedBuffersDuration_ = 0;
 
     void processWithoutInterpolation(
             const std::shared_ptr<AudioBus>& processingBus,

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <audioapi/core/sources/AudioBuffer.h>
-#include <audioapi/core/sources/AudioScheduledSourceNode.h>
+#include <audioapi/core/sources/AudioBufferBaseSourceNode.h>
 #include <audioapi/libs/signalsmith-stretch/signalsmith-stretch.h>
 
 #include <memory>
@@ -15,7 +15,7 @@ namespace audioapi {
 class AudioBus;
 class AudioParam;
 
-class AudioBufferQueueSourceNode : public AudioScheduledSourceNode {
+class AudioBufferQueueSourceNode : public AudioBufferBaseSourceNode {
  public:
     explicit AudioBufferQueueSourceNode(BaseAudioContext *context);
     ~AudioBufferQueueSourceNode() override;
@@ -30,14 +30,10 @@ class AudioBufferQueueSourceNode : public AudioScheduledSourceNode {
     void enqueueBuffer(const std::shared_ptr<AudioBuffer> &buffer, int bufferId, bool isLastBuffer);
     void disable() override;
 
-    void setOnPositionChangedCallbackId(uint64_t callbackId);
-    void setOnPositionChangedInterval(int interval);
-    void sendOnPositionChangedEvent();
-
  protected:
     std::mutex &getBufferLock();
     void processNode(const std::shared_ptr<AudioBus>& processingBus, int framesToProcess) override;
-    double getStopTime() const override;
+    double getCurrentPosition() const override;
 
  private:
     std::mutex bufferLock_;
@@ -59,10 +55,6 @@ class AudioBufferQueueSourceNode : public AudioScheduledSourceNode {
     bool isLastBuffer_ = false;
     bool isPaused_ = false;
 
-    // positionChanged event props: callbackId, update interval in frames, time since last update in frames
-    uint64_t onPositionChangedCallbackId_ = 0;
-    int onPositionChangedInterval_;
-    int onPositionChangedTime_ = 0;
     double position_ = 0;
 
     void processWithPitchCorrection(const std::shared_ptr<AudioBus> &processingBus,

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
@@ -18,21 +18,9 @@ AudioBufferSourceNode::AudioBufferSourceNode(
       loopSkip_(false),
       loopStart_(0),
       loopEnd_(0),
-      pitchCorrection_(pitchCorrection),
-      vReadIndex_(0.0) {
+      pitchCorrection_(pitchCorrection) {
   buffer_ = std::shared_ptr<AudioBuffer>(nullptr);
   alignedBus_ = std::shared_ptr<AudioBus>(nullptr);
-
-  detuneParam_ = std::make_shared<AudioParam>(
-      0.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
-  playbackRateParam_ = std::make_shared<AudioParam>(
-      1.0, MOST_NEGATIVE_SINGLE_FLOAT, MOST_POSITIVE_SINGLE_FLOAT, context);
-
-  playbackRateBus_ = std::make_shared<AudioBus>(
-      RENDER_QUANTUM_SIZE * 3, channelCount_, context_->getSampleRate());
-
-  stretch_ =
-      std::make_shared<signalsmith::stretch::SignalsmithStretch<float>>();
 
   isInitialized_ = true;
 }
@@ -58,15 +46,6 @@ double AudioBufferSourceNode::getLoopStart() const {
 
 double AudioBufferSourceNode::getLoopEnd() const {
   return loopEnd_;
-}
-
-std::shared_ptr<AudioParam> AudioBufferSourceNode::getDetuneParam() const {
-  return detuneParam_;
-}
-
-std::shared_ptr<AudioParam> AudioBufferSourceNode::getPlaybackRateParam()
-    const {
-  return playbackRateParam_;
 }
 
 std::shared_ptr<AudioBuffer> AudioBufferSourceNode::getBuffer() const {
@@ -145,10 +124,6 @@ void AudioBufferSourceNode::disable() {
   alignedBus_.reset();
 }
 
-std::mutex &AudioBufferSourceNode::getBufferLock() {
-  return bufferLock_;
-}
-
 void AudioBufferSourceNode::processNode(
     const std::shared_ptr<AudioBus> &processingBus,
     int framesToProcess) {
@@ -201,47 +176,6 @@ void AudioBufferSourceNode::processWithoutPitchCorrection(
   } else {
     processWithInterpolation(
         processingBus, startOffset, offsetLength, computedPlaybackRate);
-  }
-}
-
-void AudioBufferSourceNode::processWithPitchCorrection(
-    const std::shared_ptr<AudioBus> &processingBus,
-    int framesToProcess) {
-  size_t startOffset = 0;
-  size_t offsetLength = 0;
-
-  auto time = context_->getCurrentTime();
-  auto playbackRate = std::clamp(
-      playbackRateParam_->processKRateParam(framesToProcess, time), 0.0f, 3.0f);
-  auto detune = std::clamp(
-      detuneParam_->processKRateParam(framesToProcess, time) / 100.0f,
-      -12.0f,
-      12.0f);
-
-  playbackRateBus_->zero();
-
-  auto framesNeededToStretch =
-      static_cast<int>(playbackRate * static_cast<float>(framesToProcess));
-
-  updatePlaybackInfo(
-      playbackRateBus_, framesNeededToStretch, startOffset, offsetLength);
-
-  if (playbackRate == 0.0f || (!isPlaying() && !isStopScheduled())) {
-    processingBus->zero();
-    return;
-  }
-
-  processWithoutInterpolation(
-      playbackRateBus_, startOffset, offsetLength, playbackRate);
-
-  stretch_->process(
-      playbackRateBus_.get()[0],
-      framesNeededToStretch,
-      processingBus.get()[0],
-      framesToProcess);
-
-  if (detune != 0.0f) {
-    stretch_->setTransposeSemitones(detune);
   }
 }
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
@@ -173,8 +173,8 @@ void AudioBufferSourceNode::processNode(
 }
 
 double AudioBufferSourceNode::getCurrentPosition() const {
-    return dsp::sampleFrameToTime(
-        static_cast<int>(vReadIndex_), buffer_->getSampleRate());
+  return dsp::sampleFrameToTime(
+      static_cast<int>(vReadIndex_), buffer_->getSampleRate());
 }
 
 /**

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.h
@@ -23,8 +23,6 @@ class AudioBufferSourceNode : public AudioBufferBaseSourceNode {
   [[nodiscard]] bool getLoopSkip() const;
   [[nodiscard]] double getLoopStart() const;
   [[nodiscard]] double getLoopEnd() const;
-  [[nodiscard]] std::shared_ptr<AudioParam> getDetuneParam() const;
-  [[nodiscard]] std::shared_ptr<AudioParam> getPlaybackRateParam() const;
   [[nodiscard]] std::shared_ptr<AudioBuffer> getBuffer() const;
 
   void setLoop(bool loop);
@@ -37,7 +35,6 @@ class AudioBufferSourceNode : public AudioBufferBaseSourceNode {
   void disable() override;
 
  protected:
-  std::mutex &getBufferLock();
   void processNode(const std::shared_ptr<AudioBus>& processingBus, int framesToProcess) override;
   double getCurrentPosition() const override;
 
@@ -47,20 +44,9 @@ class AudioBufferSourceNode : public AudioBufferBaseSourceNode {
   bool loopSkip_;
   double loopStart_;
   double loopEnd_;
-  std::mutex bufferLock_;
 
   // pitch correction
   bool pitchCorrection_;
-  std::shared_ptr<signalsmith::stretch::SignalsmithStretch<float>> stretch_;
-
-  // k-rate params
-  std::shared_ptr<AudioParam> detuneParam_;
-  std::shared_ptr<AudioParam> playbackRateParam_;
-
-  std::shared_ptr<AudioBus> playbackRateBus_;
-
-  // internal helper
-  double vReadIndex_;
 
   // User provided buffer
   std::shared_ptr<AudioBuffer> buffer_;
@@ -69,14 +55,11 @@ class AudioBufferSourceNode : public AudioBufferBaseSourceNode {
   void processWithoutPitchCorrection(const std::shared_ptr<AudioBus> &processingBus,
                                      int framesToProcess);
 
-  void processWithPitchCorrection(const std::shared_ptr<AudioBus> &processingBus,
-                                  int framesToProcess);
-
   void processWithoutInterpolation(
       const std::shared_ptr<AudioBus>& processingBus,
       size_t startOffset,
       size_t offsetLength,
-      float playbackRate);
+      float playbackRate) override;
 
   void processWithInterpolation(
       const std::shared_ptr<AudioBus>& processingBus,

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <audioapi/core/sources/AudioBuffer.h>
-#include <audioapi/core/sources/AudioScheduledSourceNode.h>
+#include <audioapi/core/sources/AudioBufferBaseSourceNode.h>
 #include <audioapi/libs/signalsmith-stretch/signalsmith-stretch.h>
 
 #include <memory>
@@ -14,7 +14,7 @@ namespace audioapi {
 class AudioBus;
 class AudioParam;
 
-class AudioBufferSourceNode : public AudioScheduledSourceNode {
+class AudioBufferSourceNode : public AudioBufferBaseSourceNode {
  public:
   explicit AudioBufferSourceNode(BaseAudioContext *context, bool pitchCorrection);
   ~AudioBufferSourceNode() override;
@@ -36,14 +36,10 @@ class AudioBufferSourceNode : public AudioScheduledSourceNode {
   void start(double when, double offset, double duration = -1);
   void disable() override;
 
-  void setOnPositionChangedCallbackId(uint64_t callbackId);
-  void setOnPositionChangedInterval(int interval);
-  void sendOnPositionChangedEvent();
-
  protected:
   std::mutex &getBufferLock();
   void processNode(const std::shared_ptr<AudioBus>& processingBus, int framesToProcess) override;
-  double getStopTime() const override;
+  double getCurrentPosition() const override;
 
  private:
   // Looping related properties
@@ -69,11 +65,6 @@ class AudioBufferSourceNode : public AudioScheduledSourceNode {
   // User provided buffer
   std::shared_ptr<AudioBuffer> buffer_;
   std::shared_ptr<AudioBus> alignedBus_;
-
-    // positionChanged event props: callbackId, update interval in frames, time since last update in frames
-    uint64_t onPositionChangedCallbackId_ = 0;
-    int onPositionChangedInterval_;
-    int onPositionChangedTime_ = 0;
 
   void processWithoutPitchCorrection(const std::shared_ptr<AudioBus> &processingBus,
                                      int framesToProcess);

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -143,18 +143,8 @@ void AudioScheduledSourceNode::updatePlaybackInfo(
 void AudioScheduledSourceNode::disable() {
   AudioNode::disable();
 
-  std::string state = "stopped";
-
-  // if it has not been stopped, it is ended
-  if (stopTime_ < 0) {
-    state = "ended";
-  }
-
-  std::unordered_map<std::string, EventValue> body = {
-      {"value", getStopTime()}, {"state", state}};
-
   context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
-      "ended", onEndedCallbackId_, body);
+      "ended", onEndedCallbackId_, {});
 }
 
 void AudioScheduledSourceNode::handleStopScheduled() {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
@@ -39,7 +39,6 @@ class AudioScheduledSourceNode : public AudioNode {
 
   void setOnEndedCallbackId(uint64_t callbackId);
 
-  virtual double getStopTime() const = 0;
   void disable() override;
 
  protected:
@@ -48,6 +47,8 @@ class AudioScheduledSourceNode : public AudioNode {
 
   PlaybackState playbackState_;
 
+  uint64_t onEndedCallbackId_ = 0;
+
   void updatePlaybackInfo(
       const std::shared_ptr<AudioBus>& processingBus,
       int framesToProcess,
@@ -55,8 +56,6 @@ class AudioScheduledSourceNode : public AudioNode {
       size_t &nonSilentFramesToProcess);
 
   void handleStopScheduled();
-
-  uint64_t onEndedCallbackId_ = 0;
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/OscillatorNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/OscillatorNode.cpp
@@ -91,9 +91,4 @@ void OscillatorNode::processNode(
   handleStopScheduled();
 }
 
-double OscillatorNode::getStopTime() const {
-  return dsp::sampleFrameToTime(
-      static_cast<int>(phase_), context_->getSampleRate());
-}
-
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/OscillatorNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/OscillatorNode.h
@@ -25,7 +25,6 @@ class OscillatorNode : public AudioScheduledSourceNode {
 
  protected:
   void processNode(const std::shared_ptr<AudioBus>& processingBus, int framesToProcess) override;
-  double getStopTime() const override;
 
  private:
   std::shared_ptr<AudioParam> frequencyParam_;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.cpp
@@ -98,7 +98,7 @@ void AudioNodeManager::settlePendingConnections() {
 
 void AudioNodeManager::cleanupNode(const std::shared_ptr<AudioNode> &node) {
   nodeDeconstructor_.addNodeForDeconstruction(node);
-  node.get()->cleanup();
+  node->cleanup();
 }
 
 void AudioNodeManager::prepareNodesForDestruction() {

--- a/packages/react-native-audio-api/src/core/AudioBufferBaseSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioBufferBaseSourceNode.ts
@@ -1,0 +1,33 @@
+import { IAudioBufferBaseSourceNode } from '../interfaces';
+import AudioScheduledSourceNode from './AudioScheduledSourceNode';
+import BaseAudioContext from './BaseAudioContext';
+import AudioParam from './AudioParam';
+import { EventTypeWithValue } from '../events/types';
+
+export default class AudioBufferBaseSourceNode extends AudioScheduledSourceNode {
+  readonly playbackRate: AudioParam;
+  readonly detune: AudioParam;
+
+  constructor(context: BaseAudioContext, node: IAudioBufferBaseSourceNode) {
+    super(context, node);
+
+    this.detune = new AudioParam(node.detune, context);
+    this.playbackRate = new AudioParam(node.playbackRate, context);
+  }
+
+  // eslint-disable-next-line accessor-pairs
+  public set onPositionChanged(callback: (event: EventTypeWithValue) => void) {
+    const subscription = this.audioEventEmitter.addAudioEventListener(
+      'positionChanged',
+      callback
+    );
+
+    (this.node as IAudioBufferBaseSourceNode).onPositionChanged =
+      subscription.subscriptionId;
+  }
+
+  // eslint-disable-next-line accessor-pairs
+  public set onPositionChangedInterval(value: number) {
+    (this.node as IAudioBufferBaseSourceNode).onPositionChangedInterval = value;
+  }
+}

--- a/packages/react-native-audio-api/src/core/AudioBufferQueueSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioBufferQueueSourceNode.ts
@@ -1,22 +1,9 @@
 import { IAudioBufferQueueSourceNode } from '../interfaces';
-import AudioScheduledSourceNode from './AudioScheduledSourceNode';
-import BaseAudioContext from './BaseAudioContext';
+import AudioBufferBaseSourceNode from './AudioBufferBaseSourceNode';
 import AudioBuffer from './AudioBuffer';
-import AudioParam from './AudioParam';
 import { RangeError } from '../errors';
-import { EventTypeWithValue } from '../events/types';
 
-export default class AudioBufferQueueSourceNode extends AudioScheduledSourceNode {
-  readonly playbackRate: AudioParam;
-  readonly detune: AudioParam;
-
-  constructor(context: BaseAudioContext, node: IAudioBufferQueueSourceNode) {
-    super(context, node);
-
-    this.detune = new AudioParam(node.detune, context);
-    this.playbackRate = new AudioParam(node.playbackRate, context);
-  }
-
+export default class AudioBufferQueueSourceNode extends AudioBufferBaseSourceNode {
   public enqueueBuffer(
     buffer: AudioBuffer,
     bufferId: number = 0,
@@ -44,7 +31,7 @@ export default class AudioBufferQueueSourceNode extends AudioScheduledSourceNode
       }
     }
 
-    (this.node as IAudioBufferQueueSourceNode).start(when, offset);
+    (this.node as IAudioBufferQueueSourceNode).start(when);
   }
 
   public override stop(when: number = 0): void {
@@ -59,22 +46,5 @@ export default class AudioBufferQueueSourceNode extends AudioScheduledSourceNode
 
   public pause(): void {
     (this.node as IAudioBufferQueueSourceNode).pause();
-  }
-
-  // eslint-disable-next-line accessor-pairs
-  public set onPositionChanged(callback: (event: EventTypeWithValue) => void) {
-    const subscription = this.audioEventEmitter.addAudioEventListener(
-      'positionChanged',
-      callback
-    );
-
-    (this.node as IAudioBufferQueueSourceNode).onPositionChanged =
-      subscription.subscriptionId;
-  }
-
-  // eslint-disable-next-line accessor-pairs
-  public set onPositionChangedInterval(value: number) {
-    (this.node as IAudioBufferQueueSourceNode).onPositionChangedInterval =
-      value;
   }
 }

--- a/packages/react-native-audio-api/src/core/AudioBufferQueueSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioBufferQueueSourceNode.ts
@@ -6,12 +6,10 @@ import { RangeError } from '../errors';
 export default class AudioBufferQueueSourceNode extends AudioBufferBaseSourceNode {
   public enqueueBuffer(
     buffer: AudioBuffer,
-    bufferId: number = 0,
     isLastBuffer: boolean = false
   ): void {
     (this.node as IAudioBufferQueueSourceNode).enqueueBuffer(
       buffer.buffer,
-      bufferId,
       isLastBuffer
     );
   }

--- a/packages/react-native-audio-api/src/core/AudioBufferSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioBufferSourceNode.ts
@@ -1,22 +1,9 @@
 import { IAudioBufferSourceNode } from '../interfaces';
-import AudioScheduledSourceNode from './AudioScheduledSourceNode';
-import BaseAudioContext from './BaseAudioContext';
+import AudioBufferBaseSourceNode from './AudioBufferBaseSourceNode';
 import AudioBuffer from './AudioBuffer';
-import AudioParam from './AudioParam';
 import { InvalidStateError, RangeError } from '../errors';
-import { EventTypeWithValue } from '../events/types';
 
-export default class AudioBufferSourceNode extends AudioScheduledSourceNode {
-  readonly playbackRate: AudioParam;
-  readonly detune: AudioParam;
-
-  constructor(context: BaseAudioContext, node: IAudioBufferSourceNode) {
-    super(context, node);
-
-    this.detune = new AudioParam(node.detune, context);
-    this.playbackRate = new AudioParam(node.playbackRate, context);
-  }
-
+export default class AudioBufferSourceNode extends AudioBufferBaseSourceNode {
   public get buffer(): AudioBuffer | null {
     const buffer = (this.node as IAudioBufferSourceNode).buffer;
     if (!buffer) {
@@ -91,21 +78,5 @@ export default class AudioBufferSourceNode extends AudioScheduledSourceNode {
 
     this.hasBeenStarted = true;
     (this.node as IAudioBufferSourceNode).start(when, offset, duration);
-  }
-
-  // eslint-disable-next-line accessor-pairs
-  public set onPositionChanged(callback: (event: EventTypeWithValue) => void) {
-    const subscription = this.audioEventEmitter.addAudioEventListener(
-      'positionChanged',
-      callback
-    );
-
-    (this.node as IAudioBufferSourceNode).onPositionChanged =
-      subscription.subscriptionId;
-  }
-
-  // eslint-disable-next-line accessor-pairs
-  public set onPositionChangedInterval(value: number) {
-    (this.node as IAudioBufferSourceNode).onPositionChangedInterval = value;
   }
 }

--- a/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
@@ -1,7 +1,7 @@
 import { IAudioScheduledSourceNode } from '../interfaces';
 import AudioNode from './AudioNode';
 import { InvalidStateError, RangeError } from '../errors';
-import { OnEndedEventType } from '../events/types';
+import { EventEmptyType } from '../events/types';
 import { AudioEventEmitter } from '../events';
 
 export default class AudioScheduledSourceNode extends AudioNode {
@@ -42,7 +42,7 @@ export default class AudioScheduledSourceNode extends AudioNode {
   }
 
   // eslint-disable-next-line accessor-pairs
-  public set onended(callback: (event: OnEndedEventType) => void) {
+  public set onended(callback: (event: EventEmptyType) => void) {
     const subscription = this.audioEventEmitter.addAudioEventListener(
       'ended',
       callback

--- a/packages/react-native-audio-api/src/events/types.ts
+++ b/packages/react-native-audio-api/src/events/types.ts
@@ -1,15 +1,9 @@
 import AudioBuffer from '../core/AudioBuffer';
 
-interface EventEmptyType {}
+export interface EventEmptyType {}
 
 export interface EventTypeWithValue {
   value: number;
-}
-
-export interface OnEndedEventType {
-  value: number;
-  state: 'stopped' | 'ended';
-  bufferId: number | undefined;
 }
 
 interface OnInterruptionEventType {
@@ -57,7 +51,7 @@ export interface OnAudioReadyEventType {
 }
 
 interface AudioAPIEvents {
-  ended: OnEndedEventType;
+  ended: EventEmptyType;
   audioReady: OnAudioReadyEventType;
   positionChanged: EventTypeWithValue;
   audioError: EventEmptyType; // to change

--- a/packages/react-native-audio-api/src/interfaces.ts
+++ b/packages/react-native-audio-api/src/interfaces.ts
@@ -122,11 +122,7 @@ export interface IAudioBufferSourceNode extends IAudioBufferBaseSourceNode {
 
 export interface IAudioBufferQueueSourceNode
   extends IAudioBufferBaseSourceNode {
-  enqueueBuffer: (
-    audioBuffer: IAudioBuffer,
-    bufferId: number,
-    isLastBuffer: boolean
-  ) => void;
+  enqueueBuffer: (audioBuffer: IAudioBuffer, isLastBuffer: boolean) => void;
   pause: () => void;
 }
 

--- a/packages/react-native-audio-api/src/interfaces.ts
+++ b/packages/react-native-audio-api/src/interfaces.ts
@@ -92,6 +92,16 @@ export interface IAudioScheduledSourceNode extends IAudioNode {
   onended: string;
 }
 
+export interface IAudioBufferBaseSourceNode extends IAudioScheduledSourceNode {
+  detune: IAudioParam;
+  playbackRate: IAudioParam;
+
+  // passing subscriptionId(uint_64 in cpp, string in js) to the cpp
+  onPositionChanged: string;
+  // set how often the onPositionChanged event is called
+  onPositionChangedInterval: number;
+}
+
 export interface IOscillatorNode extends IAudioScheduledSourceNode {
   readonly frequency: IAudioParam;
   readonly detune: IAudioParam;
@@ -100,39 +110,24 @@ export interface IOscillatorNode extends IAudioScheduledSourceNode {
   setPeriodicWave(periodicWave: IPeriodicWave): void;
 }
 
-export interface IAudioBufferSourceNode extends IAudioScheduledSourceNode {
+export interface IAudioBufferSourceNode extends IAudioBufferBaseSourceNode {
   buffer: IAudioBuffer | null;
   loop: boolean;
   loopSkip: boolean;
   loopStart: number;
   loopEnd: number;
-  detune: IAudioParam;
-  playbackRate: IAudioParam;
 
   start: (when?: number, offset?: number, duration?: number) => void;
-
-  // passing subscriptionId(uint_64 in cpp, string in js) to the cpp
-  onPositionChanged: string;
-  // set how often the onPositionChanged event is called
-  onPositionChangedInterval: number;
 }
 
-export interface IAudioBufferQueueSourceNode extends IAudioScheduledSourceNode {
-  detune: IAudioParam;
-  playbackRate: IAudioParam;
-
+export interface IAudioBufferQueueSourceNode
+  extends IAudioBufferBaseSourceNode {
   enqueueBuffer: (
     audioBuffer: IAudioBuffer,
     bufferId: number,
     isLastBuffer: boolean
   ) => void;
-  start: (when: number, offset?: number) => void;
   pause: () => void;
-
-  // passing subscriptionId(uint_64 in cpp, string in js) to the cpp
-  onPositionChanged: string;
-  // set how often the onPositionChanged event is called
-  onPositionChangedInterval: number;
 }
 
 export interface IAudioBuffer {

--- a/packages/react-native-audio-api/src/web-core/AudioScheduledSourceNode.tsx
+++ b/packages/react-native-audio-api/src/web-core/AudioScheduledSourceNode.tsx
@@ -1,4 +1,5 @@
 import AudioNode from './AudioNode';
+import { EventEmptyType } from '../events/types';
 import { RangeError, InvalidStateError } from '../errors';
 
 export default class AudioScheduledSourceNode extends AudioNode {
@@ -36,11 +37,7 @@ export default class AudioScheduledSourceNode extends AudioNode {
   }
 
   // eslint-disable-next-line accessor-pairs
-  public set onended(callback: (arg?: number) => void) {
-    const eventCallback = (_event: Event) => {
-      callback();
-    };
-
-    (this.node as globalThis.AudioScheduledSourceNode).onended = eventCallback;
+  public set onended(callback: (event: EventEmptyType) => void) {
+    (this.node as globalThis.AudioScheduledSourceNode).onended = callback;
   }
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

- Aligned `onended` event type with web. Currently it has empty body.
- Changed signature of `enqueueBuffer` to `enqueueBuffer: (audioBuffer: IAudioBuffer, isLastBuffer: boolean) => void`

## Introduced changes

<!-- A brief description of the changes -->

- Implemented `AudioBufferBaseSourceNode` as a parent interface for all classes that play `AudioBuffers`

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
