### PR TITLE
fix: iOS restart engine after AVAudioSessionMediaServicesWereResetNot…

### DIFF
--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
@@ -19,6 +19,7 @@
 + (instancetype)sharedInstance;
 - (void)cleanup;
 - (bool)rebuildAudioEngine;
+- (bool)restartAudioEngine;
 - (void)startEngine;
 - (void)stopEngine;
 - (void)pauseEngine:(NSString *)sourceNodeId;

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
@@ -59,12 +59,23 @@ static AudioEngine *_sharedInstance = nil;
     [self.audioEngine connect:sourceNode to:self.audioEngine.mainMixerNode format:format];
   }
 
-  [self.audioEngine attachNode:self.inputNode];
-  [self.audioEngine connect:self.audioEngine.inputNode to:self.inputNode format:nil];
+  if (self.inputNode) {
+    [self.audioEngine attachNode:self.inputNode];
+    [self.audioEngine connect:self.audioEngine.inputNode to:self.inputNode format:nil];
+  }
 
-  [self startEngine];
+  [self startIfNecessary];
 
   return true;
+}
+
+- (bool)restartAudioEngine
+{
+  if ([self.audioEngine isRunning]) {
+    [self.audioEngine stop];
+  }
+  self.audioEngine = [[AVAudioEngine alloc] init];
+  return [self rebuildAudioEngine];
 }
 
 - (void)startEngine

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
@@ -18,6 +18,7 @@
 - (instancetype)init;
 - (void)cleanup;
 - (bool)configureAudioSession;
+- (bool)reconfigureAudioSession;
 
 - (NSNumber *)getDevicePreferredSampleRate;
 - (void)setAudioSessionOptions:(NSString *)category

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
@@ -195,6 +195,16 @@
   return true;
 }
 
+- (bool)reconfigureAudioSession
+{
+  self.hasDirtySettings = true;
+  if (self.isActive) {
+    self.isActive = false;
+    return [self setActive:true];
+  }
+  return true;
+}
+
 - (void)requestRecordingPermissions:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
 {
   if (@available(iOS 17, *)) {

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/NotificationManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/NotificationManager.mm
@@ -164,10 +164,8 @@ static NSString *VolumeObservationContext = @"VolumeObservationContext";
   AudioEngine *audioEngine = self.audioAPIModule.audioEngine;
   AudioSessionManager *audioSessionManager = self.audioAPIModule.audioSessionManager;
 
-  [self cleanup];
-  [audioSessionManager configureAudioSession];
-  [self configureNotifications];
-  [audioEngine rebuildAudioEngine];
+  [audioSessionManager reconfigureAudioSession];
+  [audioEngine restartAudioEngine];
 }
 
 - (void)handleEngineConfigurationChange:(NSNotification *)notification


### PR DESCRIPTION
…ification

<!-- Reference any GitHub issues resolved by this PR -->

Closes https://github.com/software-mansion/react-native-audio-api/issues/512

## Introduced changes

- add nil check for inputNode
- allocate a new audioEngine after reset
- apply audioSession options after reset


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
