### PR TITLE
fix: fixed sending on position change after on ended

### DIFF
--- a/apps/common-app/src/examples/AudioFile/AudioPlayer.ts
+++ b/apps/common-app/src/examples/AudioFile/AudioPlayer.ts
@@ -48,7 +48,9 @@ class AudioPlayer {
       this.seekOffset = 0;
     }
     this.sourceNode.onPositionChanged = (event) => {
-      this.offset = event.value;
+      if (this.isPlaying) {
+        this.offset = event.value;
+      }
     };
 
     this.sourceNode.start(this.audioContext.currentTime, this.offset);

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
@@ -99,6 +99,8 @@ void AudioBufferBaseSourceNode::processWithPitchCorrection(
   if (detune != 0.0f) {
     stretch_->setTransposeSemitones(detune);
   }
+
+  sendOnPositionChangedEvent();
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
@@ -70,7 +70,6 @@ void AudioBufferQueueSourceNode::processNode(
     processWithPitchCorrection(processingBus, framesToProcess);
 
     handleStopScheduled();
-    sendOnPositionChangedEvent();
   } else {
     processingBus->zero();
   }

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferSourceNode.cpp
@@ -141,7 +141,6 @@ void AudioBufferSourceNode::processNode(
     }
 
     handleStopScheduled();
-    sendOnPositionChangedEvent();
   } else {
     processingBus->zero();
   }
@@ -177,6 +176,8 @@ void AudioBufferSourceNode::processWithoutPitchCorrection(
     processWithInterpolation(
         processingBus, startOffset, offsetLength, computedPlaybackRate);
   }
+
+  sendOnPositionChangedEvent();
 }
 
 void AudioBufferSourceNode::processWithoutInterpolation(

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -73,7 +73,7 @@ void AudioScheduledSourceNode::updatePlaybackInfo(
       ? std::numeric_limits<size_t>::max()
       : dsp::timeToSampleFrame(stopTime_, sampleRate);
 
-  if (isUnscheduled() || isFinished()) {
+  if (isFinished()) {
     startOffset = 0;
     nonSilentFramesToProcess = 0;
     return;
@@ -132,6 +132,12 @@ void AudioScheduledSourceNode::updatePlaybackInfo(
 
     playbackState_ = PlaybackState::STOP_SCHEDULED;
     handleStopScheduled();
+    return;
+  }
+
+  if (isUnscheduled()) {
+    startOffset = 0;
+    nonSilentFramesToProcess = 0;
     return;
   }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #517 

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- Fixed sending `onPositionChanged` event after `onended` event

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
