### PR TITLE
More gracefull event handling from audio thread

### DIFF
--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/AudioAPIModule.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/AudioAPIModule.cpp
@@ -68,7 +68,9 @@ void AudioAPIModule::invokeHandlerWithEventNameAndEventBody(
     }
   }
 
-  audioEventHandlerRegistry_->invokeHandlerWithEventBody(
-      eventName->toStdString(), body);
+  if (audioEventHandlerRegistry_ != nullptr) {
+    audioEventHandlerRegistry_->invokeHandlerWithEventBody(
+        eventName->toStdString(), body);
+  }
 }
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferBaseSourceNodeHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioBufferBaseSourceNodeHostObject.h
@@ -18,7 +18,8 @@ class AudioBufferBaseSourceNodeHostObject
             : AudioScheduledSourceNodeHostObject(node) {
         addGetters(
                 JSI_EXPORT_PROPERTY_GETTER(AudioBufferBaseSourceNodeHostObject, detune),
-                JSI_EXPORT_PROPERTY_GETTER(AudioBufferBaseSourceNodeHostObject, playbackRate));
+                JSI_EXPORT_PROPERTY_GETTER(AudioBufferBaseSourceNodeHostObject, playbackRate),
+                JSI_EXPORT_PROPERTY_GETTER(AudioBufferBaseSourceNodeHostObject, onPositionChangedInterval));
 
         addSetters(
                 JSI_EXPORT_PROPERTY_SETTER(AudioBufferBaseSourceNodeHostObject, onPositionChanged),
@@ -47,6 +48,12 @@ class AudioBufferBaseSourceNodeHostObject
                 std::static_pointer_cast<AudioBufferBaseSourceNode>(node_);
 
         sourceNode->setOnPositionChangedCallbackId(std::stoull(value.getString(runtime).utf8(runtime)));
+    }
+
+    JSI_PROPERTY_GETTER(onPositionChangedInterval) {
+        auto sourceNode =
+                std::static_pointer_cast<AudioBufferBaseSourceNode>(node_);
+        return jsi::Value(sourceNode->getOnPositionChangedInterval());
     }
 
     JSI_PROPERTY_SETTER(onPositionChangedInterval) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioParam.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioParam.cpp
@@ -17,11 +17,10 @@ AudioParam::AudioParam(
       minValue_(minValue),
       maxValue_(maxValue),
       context_(context),
-      audioBus_(
-          std::make_shared<AudioBus>(
-              RENDER_QUANTUM_SIZE,
-              1,
-              context->getSampleRate())) {
+      audioBus_(std::make_shared<AudioBus>(
+          RENDER_QUANTUM_SIZE,
+          1,
+          context->getSampleRate())) {
   startTime_ = 0;
   endTime_ = 0;
   startValue_ = value_;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/inputs/AudioRecorder.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/inputs/AudioRecorder.cpp
@@ -36,8 +36,10 @@ void AudioRecorder::invokeOnAudioReadyCallback(
   body.insert({"numFrames", numFrames});
   body.insert({"when", when});
 
-  audioEventHandlerRegistry_->invokeHandlerWithEventBody(
-      "audioReady", onAudioReadyCallbackId_, body);
+  if (audioEventHandlerRegistry_ != nullptr) {
+    audioEventHandlerRegistry_->invokeHandlerWithEventBody(
+        "audioReady", onAudioReadyCallbackId_, body);
+  }
 }
 
 void AudioRecorder::sendRemainingData() {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
@@ -24,7 +24,8 @@ AudioBufferBaseSourceNode::AudioBufferBaseSourceNode(BaseAudioContext *context)
 }
 
 AudioBufferBaseSourceNode::~AudioBufferBaseSourceNode() {
-  if (onPositionChangedCallbackId_ != 0 && context_->audioEventHandlerRegistry_ != nullptr) {
+  if (onPositionChangedCallbackId_ != 0 &&
+      context_->audioEventHandlerRegistry_ != nullptr) {
     context_->audioEventHandlerRegistry_->unregisterHandler(
         "positionChanged", onPositionChangedCallbackId_);
     onPositionChangedCallbackId_ = 0;
@@ -60,7 +61,8 @@ std::mutex &AudioBufferBaseSourceNode::getBufferLock() {
 
 void AudioBufferBaseSourceNode::sendOnPositionChangedEvent() {
   if (onPositionChangedCallbackId_ != 0 &&
-      onPositionChangedTime_ > onPositionChangedInterval_ && context_->audioEventHandlerRegistry_ != nullptr) {
+      onPositionChangedTime_ > onPositionChangedInterval_ &&
+      context_->audioEventHandlerRegistry_ != nullptr) {
     std::unordered_map<std::string, EventValue> body = {
         {"value", getCurrentPosition()}};
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.cpp
@@ -23,6 +23,14 @@ AudioBufferBaseSourceNode::AudioBufferBaseSourceNode(BaseAudioContext *context)
       std::make_shared<signalsmith::stretch::SignalsmithStretch<float>>();
 }
 
+AudioBufferBaseSourceNode::~AudioBufferBaseSourceNode() {
+  if (onPositionChangedCallbackId_ != 0 && context_->audioEventHandlerRegistry_ != nullptr) {
+    context_->audioEventHandlerRegistry_->unregisterHandler(
+        "positionChanged", onPositionChangedCallbackId_);
+    onPositionChangedCallbackId_ = 0;
+  }
+}
+
 std::shared_ptr<AudioParam> AudioBufferBaseSourceNode::getDetuneParam() const {
   return detuneParam_;
 }
@@ -42,13 +50,17 @@ void AudioBufferBaseSourceNode::setOnPositionChangedInterval(int interval) {
       context_->getSampleRate() * static_cast<float>(interval) / 1000);
 }
 
+int AudioBufferBaseSourceNode::getOnPositionChangedInterval() {
+  return onPositionChangedInterval_;
+}
+
 std::mutex &AudioBufferBaseSourceNode::getBufferLock() {
   return bufferLock_;
 }
 
 void AudioBufferBaseSourceNode::sendOnPositionChangedEvent() {
   if (onPositionChangedCallbackId_ != 0 &&
-      onPositionChangedTime_ > onPositionChangedInterval_) {
+      onPositionChangedTime_ > onPositionChangedInterval_ && context_->audioEventHandlerRegistry_ != nullptr) {
     std::unordered_map<std::string, EventValue> body = {
         {"value", getCurrentPosition()}};
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.h
@@ -13,12 +13,14 @@ class AudioParam;
 class AudioBufferBaseSourceNode : public AudioScheduledSourceNode {
  public:
   explicit AudioBufferBaseSourceNode(BaseAudioContext *context);
+  ~AudioBufferBaseSourceNode();
 
-    [[nodiscard]] std::shared_ptr<AudioParam> getDetuneParam() const;
-    [[nodiscard]] std::shared_ptr<AudioParam> getPlaybackRateParam() const;
+  [[nodiscard]] std::shared_ptr<AudioParam> getDetuneParam() const;
+  [[nodiscard]] std::shared_ptr<AudioParam> getPlaybackRateParam() const;
 
-    void setOnPositionChangedCallbackId(uint64_t callbackId);
-    void setOnPositionChangedInterval(int interval);
+  void setOnPositionChangedCallbackId(uint64_t callbackId);
+  void setOnPositionChangedInterval(int interval);
+  [[nodiscard]] int getOnPositionChangedInterval();
 
  protected:
     std::mutex bufferLock_;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferBaseSourceNode.h
@@ -13,7 +13,7 @@ class AudioParam;
 class AudioBufferBaseSourceNode : public AudioScheduledSourceNode {
  public:
   explicit AudioBufferBaseSourceNode(BaseAudioContext *context);
-  ~AudioBufferBaseSourceNode();
+  virtual ~AudioBufferBaseSourceNode();
 
   [[nodiscard]] std::shared_ptr<AudioParam> getDetuneParam() const;
   [[nodiscard]] std::shared_ptr<AudioParam> getPlaybackRateParam() const;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -16,6 +16,14 @@ AudioScheduledSourceNode::AudioScheduledSourceNode(BaseAudioContext *context)
   numberOfInputs_ = 0;
 }
 
+AudioScheduledSourceNode::~AudioScheduledSourceNode() {
+  if (onEndedCallbackId_ != 0 && context_->audioEventHandlerRegistry_ != nullptr) {
+    context_->audioEventHandlerRegistry_->unregisterHandler(
+        "ended", onEndedCallbackId_);
+    onEndedCallbackId_ = 0;
+  }
+}
+
 void AudioScheduledSourceNode::start(double when) {
   playbackState_ = PlaybackState::SCHEDULED;
   startTime_ = when;
@@ -149,8 +157,10 @@ void AudioScheduledSourceNode::updatePlaybackInfo(
 void AudioScheduledSourceNode::disable() {
   AudioNode::disable();
 
-  context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
-      "ended", onEndedCallbackId_, {});
+  if (context_->audioEventHandlerRegistry_ != nullptr) {
+    context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
+        "ended", onEndedCallbackId_, {});
+  }
 }
 
 void AudioScheduledSourceNode::handleStopScheduled() {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.cpp
@@ -17,7 +17,8 @@ AudioScheduledSourceNode::AudioScheduledSourceNode(BaseAudioContext *context)
 }
 
 AudioScheduledSourceNode::~AudioScheduledSourceNode() {
-  if (onEndedCallbackId_ != 0 && context_->audioEventHandlerRegistry_ != nullptr) {
+  if (onEndedCallbackId_ != 0 &&
+      context_->audioEventHandlerRegistry_ != nullptr) {
     context_->audioEventHandlerRegistry_->unregisterHandler(
         "ended", onEndedCallbackId_);
     onEndedCallbackId_ = 0;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
@@ -27,7 +27,7 @@ class AudioScheduledSourceNode : public AudioNode {
   // FINISHED: The node has finished playing.
   enum class PlaybackState { UNSCHEDULED, SCHEDULED, PLAYING, STOP_SCHEDULED, FINISHED };
   explicit AudioScheduledSourceNode(BaseAudioContext *context);
-  ~AudioScheduledSourceNode();
+  virtual ~AudioScheduledSourceNode();
 
   void start(double when);
   virtual void stop(double when);

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioScheduledSourceNode.h
@@ -27,6 +27,7 @@ class AudioScheduledSourceNode : public AudioNode {
   // FINISHED: The node has finished playing.
   enum class PlaybackState { UNSCHEDULED, SCHEDULED, PLAYING, STOP_SCHEDULED, FINISHED };
   explicit AudioScheduledSourceNode(BaseAudioContext *context);
+  ~AudioScheduledSourceNode();
 
   void start(double when);
   virtual void stop(double when);

--- a/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
@@ -50,7 +50,7 @@ void AudioEventHandlerRegistry::unregisterHandler(
   callInvoker_->invokeAsync([this, eventName, listenerId]() {
     auto it = eventHandlers_.find(eventName);
 
-    if (it != eventHandlers_.end()) {
+    if (it == eventHandlers_.end()) {
       return;
     }
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
@@ -1,14 +1,5 @@
 #include <audioapi/events/AudioEventHandlerRegistry.h>
 
-/**
-
-TODO:
- - consider running register handler and unregister handler only on the main
-thread
- - LISTENER_ID should be an static atomic variable
-
-*/
-
 namespace audioapi {
 
 AudioEventHandlerRegistry::AudioEventHandlerRegistry(

--- a/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.cpp
@@ -3,7 +3,8 @@
 /**
 
 TODO:
- - consider running register handler and unregister handler only on the main thread
+ - consider running register handler and unregister handler only on the main
+thread
  - LISTENER_ID should be an static atomic variable
 
 */
@@ -75,7 +76,6 @@ void AudioEventHandlerRegistry::invokeHandlerWithEventBody(
         // If the handler is not valid, we can skip it
         continue;
       }
-
 
       auto eventObject = createEventObject(body);
       handler->call(*runtime_, eventObject);

--- a/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/events/AudioEventHandlerRegistry.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <string>
 #include <variant>
+#include <atomic>
 
 namespace audioapi {
 using namespace facebook;
@@ -27,6 +28,8 @@ class AudioEventHandlerRegistry {
   void invokeHandlerWithEventBody(const std::string &eventName, uint64_t listenerId, const std::unordered_map<std::string, EventValue> &body);
 
  private:
+    std::atomic<uint64_t> listenerIdCounter_{1}; // Atomic counter for listener IDs
+
     std::shared_ptr<react::CallInvoker> callInvoker_;
     jsi::Runtime *runtime_;
     std::unordered_map<std::string, std::unordered_map<uint64_t, std::shared_ptr<jsi::Function>>> eventHandlers_;

--- a/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
@@ -177,7 +177,9 @@ RCT_EXPORT_METHOD(
     }
   }
 
-  _eventHandler->invokeHandlerWithEventBody(name, body);
+  if (_eventHandler != nullptr) {
+    _eventHandler->invokeHandlerWithEventBody(name, body);
+  }
 }
 
 @end

--- a/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
@@ -85,9 +85,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getDevicePreferredSampleRate)
   return [self.audioSessionManager getDevicePreferredSampleRate];
 }
 
-RCT_EXPORT_METHOD(
-    setAudioSessionActivity : (BOOL)enabled resolve : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)
-        reject)
+RCT_EXPORT_METHOD(setAudioSessionActivity : (BOOL)enabled resolve : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject)
 {
   if ([self.audioSessionManager setActive:enabled]) {
     resolve(@"true");
@@ -97,9 +96,8 @@ RCT_EXPORT_METHOD(
   resolve(@"false");
 }
 
-RCT_EXPORT_METHOD(
-    setAudioSessionOptions : (NSString *)category mode : (NSString *)mode options : (NSArray *)
-        options allowHaptics : (BOOL)allowHaptics)
+RCT_EXPORT_METHOD(setAudioSessionOptions : (NSString *)category mode : (NSString *)mode options : (NSArray *)
+                      options allowHaptics : (BOOL)allowHaptics)
 {
   [self.audioSessionManager setAudioSessionOptions:category mode:mode options:options allowHaptics:allowHaptics];
 }
@@ -129,15 +127,14 @@ RCT_EXPORT_METHOD(observeVolumeChanges : (BOOL)enabled)
   [self.notificationManager observeVolumeChanges:(BOOL)enabled];
 }
 
-RCT_EXPORT_METHOD(
-    requestRecordingPermissions : (nonnull RCTPromiseResolveBlock)resolve reject : (nonnull RCTPromiseRejectBlock)
-        reject)
+RCT_EXPORT_METHOD(requestRecordingPermissions : (nonnull RCTPromiseResolveBlock)
+                      resolve reject : (nonnull RCTPromiseRejectBlock)reject)
 {
   [self.audioSessionManager requestRecordingPermissions:resolve reject:reject];
 }
 
-RCT_EXPORT_METHOD(
-    checkRecordingPermissions : (nonnull RCTPromiseResolveBlock)resolve reject : (nonnull RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(checkRecordingPermissions : (nonnull RCTPromiseResolveBlock)
+                      resolve reject : (nonnull RCTPromiseRejectBlock)reject)
 {
   [self.audioSessionManager checkRecordingPermissions:resolve reject:reject];
 }

--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio-api",
-  "version": "0.6.4556",
+  "version": "0.6.4557",
   "description": "react-native-audio-api provides system for controlling audio in React Native environment compatible with Web Audio API specification",
   "bin": {
     "setup-rn-audio-api-web": "./scripts/setup-rn-audio-api-web.js"

--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio-api",
-  "version": "0.6.4557",
+  "version": "0.6.4",
   "description": "react-native-audio-api provides system for controlling audio in React Native environment compatible with Web Audio API specification",
   "bin": {
     "setup-rn-audio-api-web": "./scripts/setup-rn-audio-api-web.js"

--- a/packages/react-native-audio-api/package.json
+++ b/packages/react-native-audio-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio-api",
-  "version": "0.6.4",
+  "version": "0.6.4556",
   "description": "react-native-audio-api provides system for controlling audio in React Native environment compatible with Web Audio API specification",
   "bin": {
     "setup-rn-audio-api-web": "./scripts/setup-rn-audio-api-web.js"

--- a/packages/react-native-audio-api/src/core/AudioBufferBaseSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioBufferBaseSourceNode.ts
@@ -1,14 +1,15 @@
+import AudioParam from './AudioParam';
+import BaseAudioContext from './BaseAudioContext';
+import { AudioEventSubscription } from '../events';
+import { EventTypeWithValue } from '../events/types';
 import { IAudioBufferBaseSourceNode } from '../interfaces';
 import AudioScheduledSourceNode from './AudioScheduledSourceNode';
-import BaseAudioContext from './BaseAudioContext';
-import AudioParam from './AudioParam';
-import { EventTypeWithValue } from '../events/types';
-import { AudioEventSubscription } from '../events';
 
 export default class AudioBufferBaseSourceNode extends AudioScheduledSourceNode {
   readonly playbackRate: AudioParam;
   readonly detune: AudioParam;
   private positionChangedSubscription?: AudioEventSubscription;
+  private positionChangedCallback?: (event: EventTypeWithValue) => void;
 
   constructor(context: BaseAudioContext, node: IAudioBufferBaseSourceNode) {
     super(context, node);
@@ -17,16 +18,25 @@ export default class AudioBufferBaseSourceNode extends AudioScheduledSourceNode 
     this.playbackRate = new AudioParam(node.playbackRate, context);
   }
 
-  // eslint-disable-next-line accessor-pairs
+  public get onPositionChanged():
+    | ((event: EventTypeWithValue) => void)
+    | undefined {
+    return this.positionChangedCallback;
+  }
+
   public set onPositionChanged(
     callback: ((event: EventTypeWithValue) => void) | null
   ) {
     if (!callback) {
+      (this.node as IAudioBufferBaseSourceNode).onPositionChanged = '0';
       this.positionChangedSubscription?.remove();
       this.positionChangedSubscription = undefined;
-      (this.node as IAudioBufferBaseSourceNode).onPositionChanged = '0';
+      this.positionChangedCallback = undefined;
+
       return;
     }
+
+    this.positionChangedCallback = callback;
     this.positionChangedSubscription =
       this.audioEventEmitter.addAudioEventListener('positionChanged', callback);
 
@@ -34,7 +44,10 @@ export default class AudioBufferBaseSourceNode extends AudioScheduledSourceNode 
       this.positionChangedSubscription.subscriptionId;
   }
 
-  // eslint-disable-next-line accessor-pairs
+  public get onPositionChangedInterval(): number {
+    return (this.node as IAudioBufferBaseSourceNode).onPositionChangedInterval;
+  }
+
   public set onPositionChangedInterval(value: number) {
     (this.node as IAudioBufferBaseSourceNode).onPositionChangedInterval = value;
   }

--- a/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
@@ -11,6 +11,7 @@ export default class AudioScheduledSourceNode extends AudioNode {
   );
 
   private onendedSubscription?: AudioEventSubscription;
+  private onEndedCallback?: (event: EventEmptyType) => void;
 
   public start(when: number = 0): void {
     if (when < 0) {
@@ -43,13 +44,20 @@ export default class AudioScheduledSourceNode extends AudioNode {
     (this.node as IAudioScheduledSourceNode).stop(when);
   }
 
-  // eslint-disable-next-line accessor-pairs
+  public get onended(): ((event: EventEmptyType) => void) | undefined {
+    return this.onEndedCallback;
+  }
+
   public set onended(callback: ((event: EventEmptyType) => void) | null) {
     if (!callback) {
+      (this.node as IAudioScheduledSourceNode).onended = '0';
       this.onendedSubscription?.remove();
       this.onendedSubscription = undefined;
+      this.onEndedCallback = undefined;
       return;
     }
+
+    this.onEndedCallback = callback;
     this.onendedSubscription = this.audioEventEmitter.addAudioEventListener(
       'ended',
       callback


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-154

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- most likely none 🤫 

## Introduced changes

<!-- A brief description of the changes -->

- adds missing getters for `onPositionChanged` callback and interval prop (eventually someone will try to console log that and will crash ;))
- add / remove event handler methods are now runned inside `invokeAsync` lambda to esnure any modification or reading from the callback map is queueud (and always on the same thread)
- invoke callback is now entirely done in the JS thread (and queue)
- atomic thread id counter!

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
