### PR TITLE
Refactor/biquad filter node

### DIFF
--- a/packages/audiodocs/docs/core/base-audio-context.mdx
+++ b/packages/audiodocs/docs/core/base-audio-context.mdx
@@ -130,6 +130,12 @@ The above method lets you create `StereoPannerNode`.
 
 #### Returns [`StereoPannerNode`](/effects/stereo-panner-node).
 
+### `createBiquadFilter
+
+The above method lets you create `BiquadFilterNode`.
+
+#### Returns [`BiquadFilterNode`](/effects/biquad-filter-node).
+
 ### `decodeAudioData`
 
 The above method lets you decode audio data. It decodes with in memory audio data block.

--- a/packages/audiodocs/docs/effects/biquad-filter-node.mdx
+++ b/packages/audiodocs/docs/effects/biquad-filter-node.mdx
@@ -20,23 +20,13 @@ Multiple `BiquadFilterNode` instances can be combined to create more complex fil
 
 ## Properties
 
-Version 1:
-| Name | Type | Description | |
-| :--: | :--: | :---------- | :-: |
-| `frequency` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` specifies the frequency at which the filter operates, measured in hertz (Hz). | <ReadOnly /> |
-| `detune` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing the frequency detuning in cents. | <ReadOnly /> |
-| `Q` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing the filter’s Q factor (quality factor). | <ReadOnly /> |
-| `gain` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing the gain used by certain filter types, in decibels (dB). | <ReadOnly /> |
-| `type` | `string` | Defines the kind of filtering algorithm the node applies (e.g., `"lowpass"`, `"highpass"`). | — |
-
-Version 2:
-| Property | Type |  Rate  | Description | |
-| :--: | :--: | :----------: | :-- | :-:|
-| `frequency` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | The filter’s cutoff or center frequency in hertz (Hz) | <ReadOnly /> |
-| `detune` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | Amount by which the frequency is detuned in cents | <ReadOnly /> |
-| `Q` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | The filter’s Q factor (quality factor) | <ReadOnly /> |
-| `gain` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | Gain applied by specific filter types, in decibels (dB) | <ReadOnly /> |
-| `type` | `string` | — | Defines the kind of filtering algorithm the node applies | — |
+| Name | Type |  Rate  | Description |
+| :--: | :--: | :----------: | :-- |
+| `frequency` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | The filter’s cutoff or center frequency in hertz (Hz) |
+| `detune` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | Amount by which the frequency is detuned in cents |
+| `Q` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | The filter’s Q factor (quality factor). |
+| `gain` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | Gain applied by specific filter types, in decibels (dB) |
+| `type` | `string` | — | Defines the kind of filtering algorithm the node applies (e.g. `"lowpass"`, `"highpass"`). |
 
 #### BiquadFilterType enumeration description
 | `type` | Description | `frequency` | `Q` | `gain` |

--- a/packages/audiodocs/docs/effects/biquad-filter-node.mdx
+++ b/packages/audiodocs/docs/effects/biquad-filter-node.mdx
@@ -38,13 +38,9 @@ Version 2:
 | `gain` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | Gain applied by specific filter types, in decibels (dB) | <ReadOnly /> |
 | `type` | `string` | — | Defines the kind of filtering algorithm the node applies | — |
 
-
-Filter parameters behave differently depending on the chosen filter type.
-TODO: detune
-
 #### BiquadFilterType enumeration description
 | `type` | Description | `frequency` | `Q` | `gain` |
-|--------|-------------|-------------|-----|--------|
+|:------:|:-----------:|:-----------:|:---:|:------:|
 | `lowpass` | Second-order resonant lowpass filter with 12dB/octave rolloff. Frequencies below the cutoff pass through; higher frequencies are attenuated. | The cutoff frequency. | Determines how peaked the frequency is around the cutoff. Higher values result in a sharper peak. | Not used |
 | `highpass` | Second-order resonant highpass filter with 12dB/octave rolloff. Frequencies above the cutoff pass through; lower frequencies are attenuated. | The cutoff frequency. | Determines how peaked the frequency is around the cutoff. Higher values result in a sharper peak.  | Not used |
 | `bandpass` | Second-order bandpass filter. Frequencies within a given range pass through; others are attenuated. | The center of the frequency band. | Controls the bandwidth. Higher values result in a narrower band. | Not used |

--- a/packages/audiodocs/docs/effects/biquad-filter-node.mdx
+++ b/packages/audiodocs/docs/effects/biquad-filter-node.mdx
@@ -1,0 +1,78 @@
+---
+sidebar_position: 1
+---
+
+import AudioNodePropsTable from "@site/src/components/AudioNodePropsTable"
+import { ReadOnly } from '@site/src/components/Badges';
+
+# BiquadFilterNode
+
+The `BiquadFilterNode` interface represents a low-order filter. It is an [`AudioNode`](/core/audio-node) used for tone controls, graphic equalizers, and other audio effects.
+Multiple `BiquadFilterNode` instances can be combined to create more complex filtering chains.
+
+
+#### [`AudioNode`](/core/audio-node#read-only-properties) properties
+<AudioNodePropsTable numberOfInputs={1} numberOfOutputs={1} channelCount={2} channelCountMode={"max"} channelInterpretation={"speakers"} />
+
+## Constructor
+
+[`BaseAudioContext.createBiquadFilter()`](/core/base-audio-context#createbiquadfilter)
+
+## Properties
+
+Version 1:
+| Name | Type | Description | |
+| :--: | :--: | :---------- | :-: |
+| `frequency` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` specifies the frequency at which the filter operates, measured in hertz (Hz). | <ReadOnly /> |
+| `detune` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing the frequency detuning in cents. | <ReadOnly /> |
+| `Q` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing the filter’s Q factor (quality factor). | <ReadOnly /> |
+| `gain` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing the gain used by certain filter types, in decibels (dB). | <ReadOnly /> |
+| `type` | `string` | Defines the kind of filtering algorithm the node applies (e.g., `"lowpass"`, `"highpass"`). | — |
+
+Version 2:
+| Property | Type |  Rate  | Description | |
+| :--: | :--: | :----------: | :-- | :-:|
+| `frequency` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | The filter’s cutoff or center frequency in hertz (Hz) | <ReadOnly /> |
+| `detune` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | Amount by which the frequency is detuned in cents | <ReadOnly /> |
+| `Q` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | The filter’s Q factor (quality factor) | <ReadOnly /> |
+| `gain` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) | Gain applied by specific filter types, in decibels (dB) | <ReadOnly /> |
+| `type` | `string` | — | Defines the kind of filtering algorithm the node applies | — |
+
+
+Filter parameters behave differently depending on the chosen filter type.
+TODO: detune
+
+#### BiquadFilterType enumeration description
+| `type` | Description | `frequency` | `Q` | `gain` |
+|--------|-------------|-------------|-----|--------|
+| `lowpass` | Second-order resonant lowpass filter with 12dB/octave rolloff. Frequencies below the cutoff pass through; higher frequencies are attenuated. | The cutoff frequency. | Determines how peaked the frequency is around the cutoff. Higher values result in a sharper peak. | Not used |
+| `highpass` | Second-order resonant highpass filter with 12dB/octave rolloff. Frequencies above the cutoff pass through; lower frequencies are attenuated. | The cutoff frequency. | Determines how peaked the frequency is around the cutoff. Higher values result in a sharper peak.  | Not used |
+| `bandpass` | Second-order bandpass filter. Frequencies within a given range pass through; others are attenuated. | The center of the frequency band. | Controls the bandwidth. Higher values result in a narrower band. | Not used |
+| `lowshelf` | Second-order lowshelf filter. Frequencies below the cutoff are boosted or attenuated; others remain unchanged. | The upper limit of the frequencies where the boost (or attenuation) is applied. | Not used | The boost (in dB) to be applied. Negative values attenuate the frequencies.|
+| `highshelf` | Second-order highshelf filter. Frequencies above the cutoff are boosted or attenuated; others remain unchanged. | The lower limit of the frequencies where the boost (or attenuation) is applied. | Not used | The boost (in dB) to be applied. Negative values attenuate the frequencies. |
+| `peaking` | Frequencies around a center frequency are boosted or attenuated; others remain unchanged. | The center of the frequency range where the boost (or an attenuation) is applied. | Controls the bandwidth. Higher values result in a narrower band. | The boost (in dB) to be applied. Negative values attenuate the frequencies. |
+| `notch` | Notch (band-stop) filter. Opposite of a bandpass filter: frequencies around the center are attenuated; others remain unchanged. | The center of the frequency range where the notch is applied. | Controls the bandwidth. Higher values result in a narrower band. | Not used |
+| `allpass` | Second-order allpass filter. All frequencies pass through, but changes the phase relationship between the various frequencies. | The frequency where the center of the phase transition occurs (maximum group delay). | Controls how sharp the phase transition is at the center frequency. Higher values result in a sharper transition and a larger group delay. | Not used |
+
+## Methods
+
+### `getFrequencyResponse`
+
+| Parameters | Type | Description |
+| :--------: | :--: | :---------- |
+| `frequencyArray` | `Float32Array` | Array of frequencies (in Hz), which you want to filter. |
+| `magResponseOutput` | `Float32Array` | Output array to store the computed linear magnitude values for each frequency. For frequencies outside the range [0, sampleRate / 2], the corresponding results are NaN. |
+| `phaseResponseOutput` | `Float32Array` | Output array to store the computed phase response values (in radians) for each frequency. For frequencies outside the range [0, sampleRate / 2], the corresponding results are NaN. |
+| `length` | `number` | The number of frequency values to process. It should match the length of all input and output arrays. |
+
+#### Returns `undefined`.
+
+## Remarks
+#### `frequency`
+- float, default value is 350.
+#### `detune`
+- float, default value is 0.
+#### `Q`
+- float, default value is 1.
+#### `gain`
+- [`BiquadFilterType`](#biquadfiltertype-enumeration-description), default is "lowpass".

--- a/packages/audiodocs/docs/effects/gain-node.mdx
+++ b/packages/audiodocs/docs/effects/gain-node.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 import AudioNodePropsTable from "@site/src/components/AudioNodePropsTable"

--- a/packages/audiodocs/docs/effects/stereo-panner-node.mdx
+++ b/packages/audiodocs/docs/effects/stereo-panner-node.mdx
@@ -19,9 +19,9 @@ The `StereoPannerNode` interface represents the change in ratio between two outp
 
 ## Properties
 
-| Name | Type | Description | |
-| :--: | :--: | :---------- | :-: |
-| `pan` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing how the audio signal is distributed between the left and right channels. | <ReadOnly />
+| Name | Type | Description |
+| :--: | :--: | :---------- |
+| `pan` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing how the audio signal is distributed between the left and right channels. |
 
 ## Remarks
 

--- a/packages/audiodocs/docs/effects/stereo-panner-node.mdx
+++ b/packages/audiodocs/docs/effects/stereo-panner-node.mdx
@@ -11,7 +11,7 @@ The `StereoPannerNode` interface represents the change in ratio between two outp
 
 #### [`AudioNode`](/core/audio-node#read-only-properties) properties
 
-<AudioNodePropsTable numberOfInputs={1} numberOfOutputs={1} channelCount={2} channelCountMode={"explicit"} channelInterpretation={"speakers"} />
+<AudioNodePropsTable numberOfInputs={1} numberOfOutputs={1} channelCount={2} channelCountMode={"clamped-max"} channelInterpretation={"speakers"} />
 
 ## Constructor
 
@@ -21,7 +21,7 @@ The `StereoPannerNode` interface represents the change in ratio between two outp
 
 | Name | Type | Default value | Description |
 | :----: | :----: | :-------- | :------ |
-| `pan` | [`AudioParam`](/core/audio-param) <ReadOnly /> | 0 | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing value of pan to apply. | 
+| `pan` | [`AudioParam`](/core/audio-param) <ReadOnly /> | 0 | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing | `pan` | [`AudioParam`](/core/audio-param) <ReadOnly /> | 0 | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing how the audio signal is distributed between the left and right channels. |
 
 ## Remarks
 

--- a/packages/audiodocs/docs/effects/stereo-panner-node.mdx
+++ b/packages/audiodocs/docs/effects/stereo-panner-node.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 import AudioNodePropsTable from "@site/src/components/AudioNodePropsTable"
@@ -19,11 +19,12 @@ The `StereoPannerNode` interface represents the change in ratio between two outp
 
 ## Properties
 
-| Name | Type | Default value | Description |
-| :----: | :----: | :-------- | :------ |
-| `pan` | [`AudioParam`](/core/audio-param) <ReadOnly /> | 0 | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing | `pan` | [`AudioParam`](/core/audio-param) <ReadOnly /> | 0 | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing how the audio signal is distributed between the left and right channels. |
+| Name | Type | Description | |
+| :--: | :--: | :---------- | :-: |
+| `pan` | [`AudioParam`](/core/audio-param) | [`a-rate`](/core/audio-param#a-rate-vs-k-rate) `AudioParam` representing how the audio signal is distributed between the left and right channels. | <ReadOnly />
 
 ## Remarks
 
 #### `pan`
+- Default value is 0
 - Nominal range is -1 (only left channel) to 1 (only right channel).

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/BiquadFilterNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/BiquadFilterNode.h
@@ -119,7 +119,7 @@ class BiquadFilterNode : public AudioNode {
   void setPeakingCoefficients(float frequency, float Q, float gain);
   void setNotchCoefficients(float frequency, float Q);
   void setAllpassCoefficients(float frequency, float Q);
-  void applyFilter();
+  void updateCoefficientsForFrame();
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/BiquadFilterNode.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/BiquadFilterNode.h
@@ -33,7 +33,9 @@ class BiquadFilterNode : public AudioNode {
       int length);
 
  protected:
-  void processNode(const std::shared_ptr<AudioBus>& processingBus, int framesToProcess) override;
+  void processNode(
+      const std::shared_ptr<AudioBus> &processingBus,
+      int framesToProcess) override;
 
  private:
   std::shared_ptr<AudioParam> frequencyParam_;
@@ -119,7 +121,11 @@ class BiquadFilterNode : public AudioNode {
   void setPeakingCoefficients(float frequency, float Q, float gain);
   void setNotchCoefficients(float frequency, float Q);
   void setAllpassCoefficients(float frequency, float Q);
-  void updateCoefficientsForFrame();
+  void updateCoefficientsForFrame(
+      float frequency,
+      float detune,
+      float q,
+      float gain);
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/StereoPannerNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/StereoPannerNode.cpp
@@ -34,7 +34,7 @@ void StereoPannerNode::processNode(
   // Input is mono
   if (processingBus->getNumberOfChannels() == 1) {
     for (int i = 0; i < framesToProcess; i++) {
-      auto pan = clamp(panParamValues[i], -1.0, 1.0);
+      auto pan =std::clamp(panParamValues[i], -1.0f, 1.0f);
       auto x = (pan + 1) / 2;
 
       auto gainL = static_cast<float>(cos(x * PI / 2));
@@ -48,7 +48,7 @@ void StereoPannerNode::processNode(
     }
   } else { // Input is stereo
     for (int i = 0; i < framesToProcess; i++) {
-      auto pan = clamp(panParamValues[i], -1.0, 1.0);
+      auto pan = std::clamp(panParamValues[i], -1.0f, 1.0f);
       auto x = (pan <= 0 ? pan + 1 : pan);
 
       auto gainL = static_cast<float>(cos(x * PI / 2));

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/StereoPannerNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/StereoPannerNode.cpp
@@ -10,7 +10,7 @@ namespace audioapi {
 
 StereoPannerNode::StereoPannerNode(BaseAudioContext *context)
     : AudioNode(context) {
-  channelCountMode_ = ChannelCountMode::EXPLICIT;
+  channelCountMode_ = ChannelCountMode::CLAMPED_MAX;
   panParam_ = std::make_shared<AudioParam>(0.0, -1.0f, 1.0f, context);
   isInitialized_ = true;
 }
@@ -34,7 +34,7 @@ void StereoPannerNode::processNode(
   // Input is mono
   if (processingBus->getNumberOfChannels() == 1) {
     for (int i = 0; i < framesToProcess; i++) {
-      auto pan =std::clamp(panParamValues[i], -1.0f, 1.0f);
+      auto pan = std::clamp(panParamValues[i], -1.0f, 1.0f);
       auto x = (pan + 1) / 2;
 
       auto gainL = static_cast<float>(cos(x * PI / 2));

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/StereoPannerNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/StereoPannerNode.cpp
@@ -31,26 +31,42 @@ void StereoPannerNode::processNode(
                             ->getChannel(0)
                             ->getData();
 
-  for (int i = 0; i < framesToProcess; i += 1) {
-    auto pan = panParamValues[i];
+  // Input is mono
+  if (processingBus->getNumberOfChannels() == 1) {
+    for (int i = 0; i < framesToProcess; i++) {
+      auto pan = clamp(panParamValues[i], -1.0, 1.0);
+      auto x = (pan + 1) / 2;
 
-    auto x = (pan <= 0 ? pan + 1 : pan);
+      auto gainL = static_cast<float>(cos(x * PI / 2));
+      auto gainR = static_cast<float>(sin(x * PI / 2));
 
-    auto gainL = static_cast<float>(cos(x * PI / 2));
-    auto gainR = static_cast<float>(sin(x * PI / 2));
+      float input = (*left)[i];
 
-    float inputL = (*left)[i];
-    float inputR = (*right)[i];
-
-    if (pan <= 0) {
-      (*left)[i] = inputL + inputR * gainL;
-      (*right)[i] = inputR * gainR;
-    } else {
-      (*left)[i] = inputL * gainL;
-      (*right)[i] = inputR + inputL * gainR;
+      (*left)[i] = input * gainL;
+      (*right)[i] = input * gainR;
+      time += deltaTime;
     }
+  } else { // Input is stereo
+    for (int i = 0; i < framesToProcess; i++) {
+      auto pan = clamp(panParamValues[i], -1.0, 1.0);
+      auto x = (pan <= 0 ? pan + 1 : pan);
 
-    time += deltaTime;
+      auto gainL = static_cast<float>(cos(x * PI / 2));
+      auto gainR = static_cast<float>(sin(x * PI / 2));
+
+      float inputL = (*left)[i];
+      float inputR = (*right)[i];
+
+      if (pan <= 0) {
+        (*left)[i] = inputL + inputR * gainL;
+        (*right)[i] = inputR * gainR;
+      } else {
+        (*left)[i] = inputL * gainL;
+        (*right)[i] = inputR + inputL * gainR;
+      }
+
+      time += deltaTime;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-98

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- Made BiquadFilterNode::processNode a-rate
- Simplified coefficient calculations across different filter types
- Reimplemented BiquadFilterNode::getFrequencyResponse
- Added documentation for BiquadFilterNode
- Added mono input support to StereoPannerNode

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
