### PR TITLE
Audio Context/Recorder lifecycle improvements

### DIFF
--- a/apps/common-app/src/examples/AudioFile/AudioFile.tsx
+++ b/apps/common-app/src/examples/AudioFile/AudioFile.tsx
@@ -52,6 +52,7 @@ const AudioFile: FC = () => {
     AudioManager.enableRemoteCommand('remoteSkipForward', true);
     AudioManager.enableRemoteCommand('remoteSkipBackward', true);
     AudioManager.observeAudioInterruptions(true);
+    AudioManager.activelyReclaimSession(true);
 
     const remotePlaySubscription = AudioManager.addSystemEventListener(
       'remotePlay',

--- a/packages/audiodocs/docs/system/audio-manager.mdx
+++ b/packages/audiodocs/docs/system/audio-manager.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-import { Optional, ReadOnly, OnlyiOS } from '@site/src/components/Badges';
+import { Optional, ReadOnly, OnlyiOS, Experimental } from '@site/src/components/Badges';
 
 # AudioManager
 
@@ -116,6 +116,24 @@ Resets all of the lock screen data.
 | `enabled` | `boolean` | It is used to enable/disable observing audio interruptions |
 
 #### Returns `undefined`
+
+### `activelyReclaimSession` <OnlyiOS /> <Experimental />
+
+| Parameters | Type | Description |
+| :---: | :---: | :---- |
+| `enabled` | `boolean` | It is used to enable/disable session spoofing |
+
+#### Returns `undefined`
+
+More aggressively try to reactivate the audio session during interruptions.
+
+In some cases (depends on app session settings and other apps using audio) system may never
+send the `interruption ended` event. This method will check if any other audio is playing
+and try to reactivate the audio session, as soon as there is "silence".
+Although this might change the expected behavior.
+
+Internally method uses `AVAudioSessionSilenceSecondaryAudioHintNotification` as well as
+interval polling to check if other audio is playing.
 
 ### `observeVolumeChanges`
 

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioDecoder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioDecoder.cpp
@@ -38,7 +38,8 @@ std::shared_ptr<AudioBus> AudioDecoder::decodeWithFilePath(
       &decoder, buffer.data(), totalFrameCount, &framesDecoded);
 
   if (framesDecoded == 0) {
-    // __android_log_print(ANDROID_LOG_ERROR, "AudioDecoder", "Failed to decode");
+    // __android_log_print(ANDROID_LOG_ERROR, "AudioDecoder", "Failed to
+    // decode");
 
     ma_decoder_uninit(&decoder);
     return nullptr;
@@ -88,7 +89,8 @@ std::shared_ptr<AudioBus> AudioDecoder::decodeWithMemoryBlock(
       &decoder, buffer.data(), totalFrameCount, &framesDecoded);
 
   if (framesDecoded == 0) {
-    // __android_log_print(ANDROID_LOG_ERROR, "AudioDecoder", "Failed to decode");
+    // __android_log_print(ANDROID_LOG_ERROR, "AudioDecoder", "Failed to
+    // decode");
 
     ma_decoder_uninit(&decoder);
     return nullptr;

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
@@ -47,8 +47,8 @@ bool AudioPlayer::openAudioStream() {
 
 bool AudioPlayer::start() {
   if (mStream_) {
-    mStream_->requestStart();
-    return true;
+    auto result = mStream_->requestStart();
+    return result == oboe::Result::OK;
   }
 
   return false;
@@ -62,8 +62,8 @@ void AudioPlayer::stop() {
 
 bool AudioPlayer::resume() {
   if (mStream_) {
-    mStream_->requestStart();
-    return true;
+    auto result = mStream_->requestStart();
+    return result == oboe::Result::OK;
   }
 
   return false;

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.cpp
@@ -45,10 +45,13 @@ bool AudioPlayer::openAudioStream() {
   return true;
 }
 
-void AudioPlayer::start() {
+bool AudioPlayer::start() {
   if (mStream_) {
     mStream_->requestStart();
+    return true;
   }
+
+  return false;
 }
 
 void AudioPlayer::stop() {
@@ -57,10 +60,13 @@ void AudioPlayer::stop() {
   }
 }
 
-void AudioPlayer::resume() {
+bool AudioPlayer::resume() {
   if (mStream_) {
     mStream_->requestStart();
+    return true;
   }
+
+  return false;
 }
 
 void AudioPlayer::suspend() {
@@ -76,6 +82,10 @@ void AudioPlayer::cleanup() {
     mStream_->close();
     mStream_.reset();
   }
+}
+
+bool AudioPlayer::isRunning() const {
+  return mStream_ && mStream_->getState() == oboe::StreamState::Started;
 }
 
 DataCallbackResult AudioPlayer::onAudioReady(

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioPlayer.h
@@ -19,11 +19,13 @@ class AudioPlayer : public AudioStreamDataCallback, AudioStreamErrorCallback {
       float sampleRate,
       int channelCount);
 
-  void start();
+  bool start();
   void stop();
-  void resume();
+  bool resume();
   void suspend();
   void cleanup();
+
+  bool isRunning() const;
 
   DataCallbackResult onAudioReady(
       AudioStream *oboeStream,

--- a/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
+++ b/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
@@ -91,6 +91,10 @@ class AudioAPIModule(
     MediaSessionManager.observeAudioInterruptions(enabled)
   }
 
+  override fun activelyReclaimSession(enabled: Boolean) {
+    MediaSessionManager.activelyReclaimSession(enabled)
+  }
+
   override fun observeVolumeChanges(enabled: Boolean) {
     MediaSessionManager.observeVolumeChanges(enabled)
   }

--- a/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/system/MediaSessionManager.kt
+++ b/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/system/MediaSessionManager.kt
@@ -148,6 +148,10 @@ object MediaSessionManager {
     }
   }
 
+  fun activelyReclaimSession(enabled: Boolean) {
+    // do nothing on android
+  }
+
   fun observeVolumeChanges(observe: Boolean) {
     if (observe) {
       ContextCompat.registerReceiver(

--- a/packages/react-native-audio-api/android/src/oldarch/NativeAudioAPIModuleSpec.java
+++ b/packages/react-native-audio-api/android/src/oldarch/NativeAudioAPIModuleSpec.java
@@ -68,6 +68,10 @@
 
    @ReactMethod
    @DoNotStrip
+   public abstract void activelyReclaimSession(boolean enabled);
+
+   @ReactMethod
+   @DoNotStrip
    public abstract void observeVolumeChanges(boolean enabled);
 
    @ReactMethod

--- a/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioContextHostObject.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/HostObjects/AudioContextHostObject.h
@@ -45,11 +45,6 @@ class AudioContextHostObject : public BaseAudioContextHostObject {
           auto audioContext = std::static_pointer_cast<AudioContext>(context_);
           auto result = audioContext->resume();
 
-          if (!result) {
-              promise->reject("Failed to resume audio context because it is already closed.");
-              return;
-          }
-
           promise->resolve([result](jsi::Runtime &runtime) {
             return jsi::Value(result);
           });
@@ -64,11 +59,6 @@ class AudioContextHostObject : public BaseAudioContextHostObject {
       std::thread([this, promise = std::move(promise)]() {
           auto audioContext = std::static_pointer_cast<AudioContext>(context_);
           auto result = audioContext->suspend();
-
-          if (!result) {
-            promise->reject("Failed to suspend audio context because it is already closed.");
-            return;
-          }
 
           promise->resolve([result](jsi::Runtime &runtime) {
             return jsi::Value(result);

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.cpp
@@ -63,14 +63,21 @@ bool AudioContext::resume() {
   }
 
   if (!playerHasBeenStarted_) {
-    playerHasBeenStarted_ = true;
-    audioPlayer_->start();
-  } else {
-    audioPlayer_->resume();
+    if (audioPlayer_->start()) {
+      playerHasBeenStarted_ = true;
+      state_ = ContextState::RUNNING;
+      return true;
+    }
+
+    return false;
   }
 
-  state_ = ContextState::RUNNING;
-  return true;
+  if (audioPlayer_->resume()) {
+    state_ = ContextState::RUNNING;
+    return true;
+  }
+
+  return false;
 }
 
 bool AudioContext::suspend() {
@@ -90,13 +97,13 @@ bool AudioContext::suspend() {
 
 std::function<void(std::shared_ptr<AudioBus>, int)>
 AudioContext::renderAudio() {
-  if (!isRunning() || !destination_) {
-    return [](const std::shared_ptr<AudioBus> &, int) {};
-  }
-
   return [this](const std::shared_ptr<AudioBus> &data, int frames) {
     destination_->renderAudio(data, frames);
   };
+}
+
+bool AudioContext::isDriverRunning() const {
+  return audioPlayer_->isRunning();
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioContext.h
@@ -21,6 +21,7 @@ class AudioContext : public BaseAudioContext {
   bool resume();
   bool suspend();
 
+
  private:
 #ifdef ANDROID
   std::shared_ptr<AudioPlayer> audioPlayer_;
@@ -28,6 +29,8 @@ class AudioContext : public BaseAudioContext {
   std::shared_ptr<IOSAudioPlayer> audioPlayer_;
 #endif
   bool playerHasBeenStarted_;
+
+  bool isDriverRunning() const override;
 
   std::function<void(std::shared_ptr<AudioBus>, int)> renderAudio();
 };

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioParam.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioParam.cpp
@@ -18,11 +18,10 @@ AudioParam::AudioParam(
       minValue_(minValue),
       maxValue_(maxValue),
       context_(context),
-      audioBus_(
-          std::make_shared<AudioBus>(
-              RENDER_QUANTUM_SIZE,
-              1,
-              context->getSampleRate())) {
+      audioBus_(std::make_shared<AudioBus>(
+          RENDER_QUANTUM_SIZE,
+          1,
+          context->getSampleRate())) {
   startTime_ = 0;
   endTime_ = 0;
   startValue_ = value_;

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.cpp
@@ -28,7 +28,15 @@ BaseAudioContext::BaseAudioContext(
 }
 
 std::string BaseAudioContext::getState() {
-  return BaseAudioContext::toString(state_);
+  if (isDriverRunning()) {
+    return BaseAudioContext::toString(state_);
+  }
+
+  if (state_ == ContextState::CLOSED) {
+    return BaseAudioContext::toString(ContextState::CLOSED);
+  }
+
+  return BaseAudioContext::toString(ContextState::SUSPENDED);
 }
 
 float BaseAudioContext::getSampleRate() const {
@@ -155,11 +163,11 @@ AudioNodeManager *BaseAudioContext::getNodeManager() {
 }
 
 bool BaseAudioContext::isRunning() const {
-  return state_ == ContextState::RUNNING;
+  return state_ == ContextState::RUNNING && isDriverRunning();
 }
 
 bool BaseAudioContext::isSuspended() const {
-  return state_ == ContextState::SUSPENDED;
+  return state_ == ContextState::SUSPENDED || !isDriverRunning();
 }
 
 bool BaseAudioContext::isClosed() const {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/BaseAudioContext.h
@@ -87,6 +87,8 @@ class BaseAudioContext {
   std::shared_ptr<PeriodicWave> cachedSawtoothWave_ = nullptr;
   std::shared_ptr<PeriodicWave> cachedTriangleWave_ = nullptr;
 
+  virtual bool isDriverRunning() const = 0;
+
  public:
     std::shared_ptr<IAudioEventHandlerRegistry> audioEventHandlerRegistry_;
 };

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.cpp
@@ -116,4 +116,8 @@ void OfflineAudioContext::startRendering(
   renderAudio();
 }
 
+bool OfflineAudioContext::isDriverRunning() const {
+  return true;
+}
+
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/OfflineAudioContext.h
@@ -35,6 +35,8 @@ class OfflineAudioContext : public BaseAudioContext {
   std::shared_ptr<AudioBus> resultBus_;
 
   void renderAudio();
+
+  bool isDriverRunning() const override;
 };
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/effects/BiquadFilterNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/effects/BiquadFilterNode.cpp
@@ -77,7 +77,6 @@ void BiquadFilterNode::getFrequencyResponse(
     float *magResponseOutput,
     float *phaseResponseOutput,
     const int length) {
-
   // Local copies for micro-optimization
   float b0 = b0_;
   float b1 = b1_;

--- a/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
@@ -85,9 +85,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getDevicePreferredSampleRate)
   return [self.audioSessionManager getDevicePreferredSampleRate];
 }
 
-RCT_EXPORT_METHOD(
-    setAudioSessionActivity : (BOOL)enabled resolve : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)
-        reject)
+RCT_EXPORT_METHOD(setAudioSessionActivity : (BOOL)enabled resolve : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject)
 {
   if ([self.audioSessionManager setActive:enabled]) {
     resolve(@"true");
@@ -97,9 +96,8 @@ RCT_EXPORT_METHOD(
   resolve(@"false");
 }
 
-RCT_EXPORT_METHOD(
-    setAudioSessionOptions : (NSString *)category mode : (NSString *)mode options : (NSArray *)
-        options allowHaptics : (BOOL)allowHaptics)
+RCT_EXPORT_METHOD(setAudioSessionOptions : (NSString *)category mode : (NSString *)mode options : (NSArray *)
+                      options allowHaptics : (BOOL)allowHaptics)
 {
   [self.audioSessionManager setAudioSessionOptions:category mode:mode options:options allowHaptics:allowHaptics];
 }
@@ -129,15 +127,14 @@ RCT_EXPORT_METHOD(observeVolumeChanges : (BOOL)enabled)
   [self.notificationManager observeVolumeChanges:(BOOL)enabled];
 }
 
-RCT_EXPORT_METHOD(
-    requestRecordingPermissions : (nonnull RCTPromiseResolveBlock)resolve reject : (nonnull RCTPromiseRejectBlock)
-        reject)
+RCT_EXPORT_METHOD(requestRecordingPermissions : (nonnull RCTPromiseResolveBlock)
+                      resolve reject : (nonnull RCTPromiseRejectBlock)reject)
 {
   [self.audioSessionManager requestRecordingPermissions:resolve reject:reject];
 }
 
-RCT_EXPORT_METHOD(
-    checkRecordingPermissions : (nonnull RCTPromiseResolveBlock)resolve reject : (nonnull RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(checkRecordingPermissions : (nonnull RCTPromiseResolveBlock)
+                      resolve reject : (nonnull RCTPromiseRejectBlock)reject)
 {
   [self.audioSessionManager checkRecordingPermissions:resolve reject:reject];
 }

--- a/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/AudioAPIModule.mm
@@ -122,6 +122,11 @@ RCT_EXPORT_METHOD(observeAudioInterruptions : (BOOL)enabled)
   [self.notificationManager observeAudioInterruptions:enabled];
 }
 
+RCT_EXPORT_METHOD(activelyReclaimSession : (BOOL)enabled)
+{
+  [self.notificationManager activelyReclaimSession:enabled];
+}
+
 RCT_EXPORT_METHOD(observeVolumeChanges : (BOOL)enabled)
 {
   [self.notificationManager observeVolumeChanges:(BOOL)enabled];

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.h
@@ -21,11 +21,13 @@ class IOSAudioPlayer {
       int channelCount);
   ~IOSAudioPlayer();
 
-  void start();
+  bool start();
   void stop();
-  void resume();
+  bool resume();
   void suspend();
   void cleanup();
+
+  bool isRunning() const;
 
  protected:
   std::shared_ptr<AudioBus> audioBus_;
@@ -34,4 +36,5 @@ class IOSAudioPlayer {
   int channelCount_;
   std::atomic<bool> isRunning_;
 };
+
 } // namespace audioapi

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.mm
@@ -3,6 +3,7 @@
 #include <audioapi/core/Constants.h>
 #include <audioapi/dsp/VectorMath.h>
 #include <audioapi/ios/core/IOSAudioPlayer.h>
+#include <audioapi/ios/system/AudioEngine.h>
 #include <audioapi/utils/AudioArray.h>
 #include <audioapi/utils/AudioBus.h>
 
@@ -66,6 +67,7 @@ void IOSAudioPlayer::stop()
   [audioPlayer_ stop];
 }
 
+bool IOSAudioPlayer::resume()
 {
   if (isRunning()) {
     return true;

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/IOSAudioPlayer.mm
@@ -49,14 +49,15 @@ IOSAudioPlayer::~IOSAudioPlayer()
   cleanup();
 }
 
-void IOSAudioPlayer::start()
+bool IOSAudioPlayer::start()
 {
-  if (isRunning_.load()) {
-    return;
+  if (isRunning()) {
+    return true;
   }
 
-  [audioPlayer_ start];
-  isRunning_.store(true);
+  bool success = [audioPlayer_ start];
+  isRunning_.store(success);
+  return success;
 }
 
 void IOSAudioPlayer::stop()
@@ -65,20 +66,27 @@ void IOSAudioPlayer::stop()
   [audioPlayer_ stop];
 }
 
-void IOSAudioPlayer::resume()
 {
-  if (isRunning_.load()) {
-    return;
+  if (isRunning()) {
+    return true;
   }
 
-  [audioPlayer_ resume];
-  isRunning_.store(true);
+  bool success = [audioPlayer_ resume];
+  isRunning_.store(success);
+  return success;
 }
 
 void IOSAudioPlayer::suspend()
 {
   isRunning_.store(false);
   [audioPlayer_ suspend];
+}
+
+bool IOSAudioPlayer::isRunning() const
+{
+  AudioEngine *audioEngine = [AudioEngine sharedInstance];
+
+  return isRunning_.load() && [audioEngine isRunning];
 }
 
 void IOSAudioPlayer::cleanup()

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.h
@@ -19,11 +19,11 @@ typedef void (^RenderAudioBlock)(AudioBufferList *outputBuffer, int numFrames);
                          sampleRate:(float)sampleRate
                        channelCount:(int)channelCount;
 
-- (void)start;
+- (bool)start;
 
 - (void)stop;
 
-- (void)resume;
+- (bool)resume;
 
 - (void)suspend;
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
@@ -32,13 +32,15 @@
   return self;
 }
 
-- (void)start
+- (BOOL)start
 {
   NSLog(@"[AudioPlayer] start");
 
   AudioEngine *audioEngine = [AudioEngine sharedInstance];
   assert(audioEngine != nil);
   self.sourceNodeId = [audioEngine attachSourceNode:self.sourceNode format:self.format];
+
+  return [audioEngine startIfNecessary];
 }
 
 - (void)stop
@@ -48,15 +50,18 @@
   AudioEngine *audioEngine = [AudioEngine sharedInstance];
   assert(audioEngine != nil);
   [audioEngine detachSourceNodeWithId:self.sourceNodeId];
+  [audioEngine stopIfNecessary];
   self.sourceNodeId = nil;
 }
 
-- (void)resume
+- (bool)resume
 {
   NSLog(@"[AudioPlayer] resume");
   AudioEngine *audioEngine = [AudioEngine sharedInstance];
   assert(audioEngine != nil);
   [audioEngine startEngine];
+
+  return [audioEngine startEngine];
 }
 
 - (void)suspend

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
@@ -32,7 +32,7 @@
   return self;
 }
 
-- (BOOL)start
+- (bool)start
 {
   NSLog(@"[AudioPlayer] start");
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioRecorder.m
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioRecorder.m
@@ -101,6 +101,7 @@
   AudioEngine *audioEngine = [AudioEngine sharedInstance];
   assert(audioEngine != nil);
   [audioEngine attachInputNode:self.sinkNode];
+  [audioEngine startIfNecessary];
 }
 
 - (void)stop
@@ -108,6 +109,7 @@
   AudioEngine *audioEngine = [AudioEngine sharedInstance];
   assert(audioEngine != nil);
   [audioEngine detachInputNode];
+  [audioEngine stopIfNecessary];
 }
 
 - (void)cleanup

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
@@ -20,7 +20,6 @@
 
 + (instancetype)sharedInstance;
 - (void)cleanup;
-- (void)rebuildAudioEngine;
 - (bool)rebuildAudioEngineAndStartIfNecessary;
 - (bool)restartAudioEngine;
 - (bool)startEngine;

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
@@ -7,6 +7,8 @@
 
 @interface AudioEngine : NSObject
 
+@property (nonatomic, assign) bool isInterrupted;
+@property (nonatomic, assign) bool isSupposedToBeRunning;
 @property (nonatomic, strong) AVAudioEngine *audioEngine;
 @property (nonatomic, strong) NSMutableDictionary *sourceNodes;
 @property (nonatomic, strong) NSMutableDictionary *sourceFormats;
@@ -18,17 +20,27 @@
 
 + (instancetype)sharedInstance;
 - (void)cleanup;
-- (bool)rebuildAudioEngine;
+- (void)rebuildAudioEngine;
+- (bool)rebuildAudioEngineAndStartIfNecessary;
 - (bool)restartAudioEngine;
-- (void)startEngine;
+- (bool)startEngine;
 - (void)stopEngine;
 - (void)pauseEngine:(NSString *)sourceNodeId;
 - (bool)isRunning;
+- (void)markAsInterrupted;
+- (void)unmarkAsInterrupted;
+- (bool)isSupposedToRun;
 
 - (NSString *)attachSourceNode:(AVAudioSourceNode *)sourceNode format:(AVAudioFormat *)format;
 - (void)detachSourceNodeWithId:(NSString *)sourceNodeId;
 
 - (void)attachInputNode:(AVAudioSinkNode *)inputNode;
 - (void)detachInputNode;
+
+- (void)logAudioEngineState;
+
+- (bool)startIfNecessary;
+- (void)stopIfNecessary;
+- (void)pauseIfNecessary;
 
 @end

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
@@ -49,10 +49,6 @@ static AudioEngine *_sharedInstance = nil;
 
 - (void)rebuildAudioEngine
 {
-  if ([self.audioEngine isRunning]) {
-    return true;
-  }
-
   for (id sourceNodeId in self.sourceNodes) {
     AVAudioSourceNode *sourceNode = [self.sourceNodes valueForKey:sourceNodeId];
     AVAudioFormat *format = [self.sourceFormats valueForKey:sourceNodeId];
@@ -242,7 +238,7 @@ static AudioEngine *_sharedInstance = nil;
 
   for (NSString *sourceId in self.sourceStates) {
     if ([self.sourceStates[sourceId] boolValue]) {
-      NSLog(@"state %c", self.sourceStates[sourceId]);
+      NSLog(@"state %@", self.sourceStates[sourceId]);
       return;
     }
   }

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
@@ -13,6 +13,8 @@ static AudioEngine *_sharedInstance = nil;
 - (instancetype)initWithAudioSessionManager:(AudioSessionManager *)sessionManager
 {
   if (self = [super init]) {
+    self.isInterrupted = false;
+    self.isSupposedToBeRunning = true;
     self.audioEngine = [[AVAudioEngine alloc] init];
     self.inputNode = nil;
 
@@ -45,7 +47,7 @@ static AudioEngine *_sharedInstance = nil;
   self.sessionManager = nil;
 }
 
-- (bool)rebuildAudioEngine
+- (void)rebuildAudioEngine
 {
   if ([self.audioEngine isRunning]) {
     return true;
@@ -63,10 +65,12 @@ static AudioEngine *_sharedInstance = nil;
     [self.audioEngine attachNode:self.inputNode];
     [self.audioEngine connect:self.audioEngine.inputNode to:self.inputNode format:nil];
   }
+}
 
-  [self startIfNecessary];
-
-  return true;
+- (bool)rebuildAudioEngineAndStartIfNecessary
+{
+  [self rebuildAudioEngine];
+  return [self startIfNecessary];
 }
 
 - (bool)restartAudioEngine
@@ -74,25 +78,45 @@ static AudioEngine *_sharedInstance = nil;
   if ([self.audioEngine isRunning]) {
     [self.audioEngine stop];
   }
+
   self.audioEngine = [[AVAudioEngine alloc] init];
-  return [self rebuildAudioEngine];
+  return [self rebuildAudioEngineAndStartIfNecessary];
 }
 
-- (void)startEngine
+- (bool)startEngine
 {
   NSLog(@"[AudioEngine] startEngine");
   NSError *error = nil;
+  self.isSupposedToBeRunning = true;
 
-  if ([self.audioEngine isRunning]) {
-    return;
+  if ([self.audioEngine isRunning] && ![self isInterrupted]) {
+    NSLog(@"[AudioEngine] Engine is already running");
+    return true;
   }
 
-  [self.sessionManager setActive:true];
+  if (![self.sessionManager setActive:true]) {
+    return false;
+  }
+
+  if ([self isInterrupted]) {
+    NSLog(@"[AudioEngine] rebuilding after interruption");
+    [self.audioEngine stop];
+    [self.audioEngine reset];
+
+    [self rebuildAudioEngine];
+
+    self.isInterrupted = false;
+  }
+
+  [self.audioEngine prepare];
   [self.audioEngine startAndReturnError:&error];
 
   if (error != nil) {
     NSLog(@"Error while starting the audio engine: %@", [error debugDescription]);
+    return false;
   }
+
+  return true;
 }
 
 - (void)stopEngine
@@ -102,11 +126,15 @@ static AudioEngine *_sharedInstance = nil;
     return;
   }
 
+  self.isSupposedToBeRunning = false;
   [self.audioEngine stop];
 }
 
 - (void)pauseEngine:(NSString *)sourceNodeId
 {
+  NSLog(@"[AudioEngine] pauseEngine");
+  self.isSupposedToBeRunning = false;
+
   if (![self.audioEngine isRunning]) {
     return;
   }
@@ -117,7 +145,18 @@ static AudioEngine *_sharedInstance = nil;
 
 - (bool)isRunning
 {
-  return [self.audioEngine isRunning];
+  return [self.audioEngine isRunning] && !self.isInterrupted;
+}
+
+- (void)markAsInterrupted
+{
+  self.isInterrupted = true;
+  self.isSupposedToBeRunning = false;
+}
+
+- (void)unmarkAsInterrupted
+{
+  self.isInterrupted = false;
 }
 
 - (NSString *)attachSourceNode:(AVAudioSourceNode *)sourceNode format:(AVAudioFormat *)format
@@ -132,7 +171,6 @@ static AudioEngine *_sharedInstance = nil;
   [self.audioEngine attachNode:sourceNode];
   [self.audioEngine connect:sourceNode to:self.audioEngine.mainMixerNode format:format];
 
-  [self startIfNecessary];
   return sourceNodeId;
 }
 
@@ -142,15 +180,16 @@ static AudioEngine *_sharedInstance = nil;
 
   AVAudioSourceNode *sourceNode = [self.sourceNodes valueForKey:sourceNodeId];
 
-  if (sourceNode != nil) {
-    [self.audioEngine detachNode:sourceNode];
-
-    [self.sourceNodes removeObjectForKey:sourceNodeId];
-    [self.sourceFormats removeObjectForKey:sourceNodeId];
-    [self.sourceStates removeObjectForKey:sourceNodeId];
+  if (sourceNode == nil) {
+    NSLog(@"[AudioEngine] No source node found with ID: %@", sourceNodeId);
+    return;
   }
 
-  [self stopIfNecessary];
+  [self.audioEngine detachNode:sourceNode];
+
+  [self.sourceNodes removeObjectForKey:sourceNodeId];
+  [self.sourceFormats removeObjectForKey:sourceNodeId];
+  [self.sourceStates removeObjectForKey:sourceNodeId];
 }
 
 - (void)attachInputNode:(AVAudioSinkNode *)inputNode
@@ -159,29 +198,29 @@ static AudioEngine *_sharedInstance = nil;
 
   [self.audioEngine attachNode:inputNode];
   [self.audioEngine connect:self.audioEngine.inputNode to:inputNode format:nil];
-
-  [self startIfNecessary];
 }
 
 - (void)detachInputNode
 {
-  if (self.inputNode != nil) {
-    [self.audioEngine detachNode:self.inputNode];
-    self.inputNode = nil;
-  }
-
-  [self stopIfNecessary];
-}
-
-- (void)startIfNecessary
-{
-  if ([self isRunning]) {
+  if (self.inputNode == nil) {
     return;
   }
 
-  if ([self.sourceNodes count] > 0 || self.inputNode != nil) {
-    [self startEngine];
+  [self.audioEngine detachNode:self.inputNode];
+  self.inputNode = nil;
+}
+
+- (bool)startIfNecessary
+{
+  if ([self isRunning]) {
+    return true;
   }
+
+  if ([self.sourceNodes count] > 0 || self.inputNode != nil) {
+    return [self startEngine];
+  }
+
+  return false;
 }
 
 - (void)stopIfNecessary
@@ -210,6 +249,47 @@ static AudioEngine *_sharedInstance = nil;
 
   NSLog(@"[AudioEngine] pauseEngine");
   [self.audioEngine pause];
+}
+
+- (void)logAudioEngineState
+{
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+
+  NSLog(@"================ 🎧 AVAudioEngine STATE ================");
+
+  // AVAudioEngine state
+  NSLog(@"➡️ engine.isRunning: %@", self.audioEngine.isRunning ? @"YES" : @"NO");
+  NSLog(@"➡️ engine.isInManualRenderingMode: %@", self.audioEngine.isInManualRenderingMode ? @"YES" : @"NO");
+
+  // Session state
+  NSLog(@"🎚️ Session category: %@", session.category);
+  NSLog(@"🎚️ Session mode: %@", session.mode);
+  NSLog(@"🎚️ Session sampleRate: %f Hz", session.sampleRate);
+  NSLog(@"🎚️ Session IO buffer duration: %f s", session.IOBufferDuration);
+
+  // Current route
+  AVAudioSessionRouteDescription *route = session.currentRoute;
+
+  NSLog(@"🔊 Current audio route outputs:");
+  for (AVAudioSessionPortDescription *output in route.outputs) {
+    NSLog(@"  Output: %@ (%@)", output.portType, output.portName);
+  }
+
+  NSLog(@"🎤 Current audio route inputs:");
+  for (AVAudioSessionPortDescription *input in route.inputs) {
+    NSLog(@"  Input: %@ (%@)", input.portType, input.portName);
+  }
+
+  // Output node format
+  AVAudioFormat *format = [self.audioEngine.outputNode inputFormatForBus:0];
+  NSLog(@"📐 Engine output format: %.0f Hz, %u channels", format.sampleRate, format.channelCount);
+
+  NSLog(@"=======================================================");
+}
+
+- (bool)isSupposedToRun
+{
+  return self.isSupposedToBeRunning;
 }
 
 @end

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.h
@@ -19,6 +19,7 @@
 - (void)cleanup;
 - (bool)configureAudioSession;
 - (bool)reconfigureAudioSession;
+- (void)markSettingsAsDirty;
 
 - (NSNumber *)getDevicePreferredSampleRate;
 - (void)setAudioSessionOptions:(NSString *)category

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioSessionManager.mm
@@ -205,6 +205,12 @@
   return true;
 }
 
+- (void)markSettingsAsDirty
+{
+  self.hasDirtySettings = true;
+  self.isActive = false;
+}
+
 - (void)requestRecordingPermissions:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
 {
   if (@available(iOS 17, *)) {

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/NotificationManager.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/NotificationManager.h
@@ -11,9 +11,11 @@
 @property (nonatomic, weak) NSNotificationCenter *notificationCenter;
 
 @property (nonatomic, assign) bool isInterrupted;
+@property (nonatomic, strong) NSTimer *hintPollingTimer;
 @property (nonatomic, assign) bool hadConfigurationChange;
 @property (nonatomic, assign) bool audioInterruptionsObserved;
 @property (nonatomic, assign) bool volumeChangesObserved;
+@property (nonatomic, assign) bool wasOtherAudioPlaying;
 
 - (instancetype)initWithAudioAPIModule:(AudioAPIModule *)audioAPIModule;
 - (void)cleanup;

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/NotificationManager.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/NotificationManager.h
@@ -21,6 +21,7 @@
 - (void)cleanup;
 
 - (void)observeAudioInterruptions:(BOOL)enabled;
+- (void)activelyReclaimSession:(BOOL)enabled;
 - (void)observeVolumeChanges:(BOOL)enabled;
 - (void)observeValueForKeyPath:(NSString *)keyPath
                       ofObject:(id)object

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/NotificationManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/NotificationManager.mm
@@ -5,7 +5,7 @@
 
 @implementation NotificationManager
 
-static NSString *VolumeObservationContext = @"VolumeObservationContext";
+static NSString *NotificationManagerContext = @"NotificationManagerContext";
 
 - (instancetype)initWithAudioAPIModule:(AudioAPIModule *)audioAPIModule
 {
@@ -16,6 +16,7 @@ static NSString *VolumeObservationContext = @"VolumeObservationContext";
 
     [self configureNotifications];
   }
+
   return self;
 }
 
@@ -28,19 +29,6 @@ static NSString *VolumeObservationContext = @"VolumeObservationContext";
 
 - (void)observeAudioInterruptions:(BOOL)enabled
 {
-  if (self.audioInterruptionsObserved == enabled) {
-    return;
-  }
-
-  if (enabled) {
-    [self.notificationCenter addObserver:self
-                                selector:@selector(handleInterruption:)
-                                    name:AVAudioSessionInterruptionNotification
-                                  object:nil];
-  } else {
-    [self.notificationCenter removeObserver:self name:AVAudioSessionInterruptionNotification object:nil];
-  }
-
   self.audioInterruptionsObserved = enabled;
 }
 
@@ -55,23 +43,12 @@ static NSString *VolumeObservationContext = @"VolumeObservationContext";
     [[AVAudioSession sharedInstance] addObserver:self
                                       forKeyPath:@"outputVolume"
                                          options:NSKeyValueObservingOptionNew
-                                         context:(void *)&VolumeObservationContext];
+                                         context:(void *)&NotificationManagerContext];
   } else {
     [[AVAudioSession sharedInstance] removeObserver:self forKeyPath:@"outputVolume" context:nil];
   }
+
   self.volumeChangesObserved = enabled;
-}
-
-- (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
-                        change:(NSDictionary *)change
-                       context:(void *)context
-{
-  if ([keyPath isEqualToString:@"outputVolume"] && context == &VolumeObservationContext) {
-    NSDictionary *body = @{@"value" : [NSNumber numberWithFloat:[change[@"new"] floatValue]]};
-
-    [self.audioAPIModule invokeHandlerWithEventName:@"volumeChange" eventBody:body];
-  }
 }
 
 - (void)configureNotifications
@@ -88,34 +65,103 @@ static NSString *VolumeObservationContext = @"VolumeObservationContext";
                               selector:@selector(handleEngineConfigurationChange:)
                                   name:AVAudioEngineConfigurationChangeNotification
                                 object:nil];
+  [self.notificationCenter addObserver:self
+                              selector:@selector(handleInterruption:)
+                                  name:AVAudioSessionInterruptionNotification
+                                object:nil];
+
+  [self.notificationCenter addObserver:self
+                              selector:@selector(handleSecondaryAudio:)
+                                  name:AVAudioSessionSilenceSecondaryAudioHintNotification
+                                object:nil];
+
+  [self startPollingSecondaryAudioHint];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context
+{
+  if (context != &NotificationManagerContext) {
+    return;
+  }
+
+  if ([keyPath isEqualToString:@"outputVolume"]) {
+    NSDictionary *body = @{@"value" : [NSNumber numberWithFloat:[change[@"new"] floatValue]]};
+    if (self.volumeChangesObserved) {
+      [self.audioAPIModule invokeHandlerWithEventName:@"volumeChange" eventBody:body];
+    }
+  }
 }
 
 - (void)handleInterruption:(NSNotification *)notification
 {
-  if (!self.audioInterruptionsObserved) {
-    return;
-  }
-
+  AudioEngine *audioEngine = self.audioAPIModule.audioEngine;
   NSInteger interruptionType = [notification.userInfo[AVAudioSessionInterruptionTypeKey] integerValue];
   NSInteger interruptionOption = [notification.userInfo[AVAudioSessionInterruptionOptionKey] integerValue];
 
   if (interruptionType == AVAudioSessionInterruptionTypeBegan) {
-    NSDictionary *body = @{@"type" : @"began", @"shouldResume" : @false};
+    [audioEngine markAsInterrupted];
 
-    [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+    if (self.audioInterruptionsObserved) {
+      NSDictionary *body = @{@"type" : @"began", @"shouldResume" : @false};
+      [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+    }
+
     return;
   }
 
   if (interruptionOption == AVAudioSessionInterruptionOptionShouldResume) {
-    NSDictionary *body = @{@"type" : @"ended", @"shouldResume" : @true};
+    [audioEngine unmarkAsInterrupted];
 
-    [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+    if (self.audioInterruptionsObserved) {
+      NSDictionary *body = @{@"type" : @"ended", @"shouldResume" : @true};
+      [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+    }
+
     return;
   }
 
-  NSDictionary *body = @{@"type" : @"ended", @"shouldResume" : @false};
+  if (self.audioInterruptionsObserved) {
+    NSDictionary *body = @{@"type" : @"ended", @"shouldResume" : @false};
+    [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+  }
+}
 
-  [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+- (void)handleSecondaryAudio:(NSNotification *)notification
+{
+  AudioEngine *audioEngine = self.audioAPIModule.audioEngine;
+  NSInteger secondaryAudioType = [notification.userInfo[AVAudioSessionSilenceSecondaryAudioHintTypeKey] integerValue];
+
+  NSLog(@"handleSecondaryAudio");
+
+  if (secondaryAudioType == AVAudioSessionSilenceSecondaryAudioHintTypeBegin) {
+    [audioEngine markAsInterrupted];
+
+    if (self.audioInterruptionsObserved) {
+      NSDictionary *body = @{@"type" : @"began", @"shouldResume" : @false};
+      [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+    }
+
+    return;
+  }
+
+  if (secondaryAudioType == AVAudioSessionSilenceSecondaryAudioHintTypeEnd) {
+    [audioEngine unmarkAsInterrupted];
+
+    if (self.audioInterruptionsObserved) {
+      NSDictionary *body = @{@"type" : @"ended", @"shouldResume" : @true};
+      [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+    }
+
+    return;
+  }
+
+  if (self.audioInterruptionsObserved) {
+    NSDictionary *body = @{@"type" : @"ended", @"shouldResume" : @false};
+    [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+  }
 }
 
 - (void)handleRouteChange:(NSNotification *)notification
@@ -171,23 +217,71 @@ static NSString *VolumeObservationContext = @"VolumeObservationContext";
 - (void)handleEngineConfigurationChange:(NSNotification *)notification
 {
   AudioEngine *audioEngine = self.audioAPIModule.audioEngine;
+  AudioSessionManager *sessionManager = self.audioAPIModule.audioSessionManager;
 
-  if (![audioEngine isRunning]) {
-    NSLog(
-        @"[NotificationManager] detected engine configuration change when engine is not running, marking for rebuild");
-    self.hadConfigurationChange = true;
-    return;
-  }
-
-  if (self.isInterrupted) {
-    NSLog(@"[NotificationManager] detected engine configuration change during interruption, marking for rebuild");
-    self.hadConfigurationChange = true;
+  if (![audioEngine isSupposedToBeRunning]) {
+    NSLog(@"[NotificationManager] detected engine configuration change when engine is not running");
+    [sessionManager markSettingsAsDirty];
     return;
   }
 
   dispatch_async(dispatch_get_main_queue(), ^{
+    [sessionManager markSettingsAsDirty];
     [audioEngine rebuildAudioEngine];
   });
+}
+
+- (void)startPollingSecondaryAudioHint
+{
+  if (self.hintPollingTimer) {
+    [self.hintPollingTimer invalidate];
+    self.hintPollingTimer = nil;
+  }
+
+  self.wasOtherAudioPlaying = false;
+  self.hintPollingTimer = [NSTimer scheduledTimerWithTimeInterval:0.5
+                                                           target:self
+                                                         selector:@selector(checkSecondaryAudioHint)
+                                                         userInfo:nil
+                                                          repeats:YES];
+
+  [[NSRunLoop mainRunLoop] addTimer:self.hintPollingTimer forMode:NSRunLoopCommonModes];
+}
+
+- (void)stopPollingSecondaryAudioHint
+{
+  [self.hintPollingTimer invalidate];
+  self.hintPollingTimer = nil;
+}
+
+- (void)checkSecondaryAudioHint
+{
+  BOOL shouldSilence = [AVAudioSession sharedInstance].secondaryAudioShouldBeSilencedHint;
+
+  if (shouldSilence == self.wasOtherAudioPlaying) {
+    return;
+  }
+
+  AudioEngine *audioEngine = self.audioAPIModule.audioEngine;
+  self.wasOtherAudioPlaying = shouldSilence;
+
+  if (shouldSilence) {
+    [audioEngine markAsInterrupted];
+    NSDictionary *body = @{@"type" : @"began", @"shouldResume" : @false};
+
+    if (self.audioInterruptionsObserved) {
+      [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+    }
+
+    return;
+  }
+
+  [audioEngine unmarkAsInterrupted];
+  NSDictionary *body = @{@"type" : @"ended", @"shouldResume" : @true};
+
+  if (self.audioInterruptionsObserved) {
+    [self.audioAPIModule invokeHandlerWithEventName:@"interruption" eventBody:body];
+  }
 }
 
 @end

--- a/packages/react-native-audio-api/src/core/AudioContext.ts
+++ b/packages/react-native-audio-api/src/core/AudioContext.ts
@@ -24,15 +24,15 @@ export default class AudioContext extends BaseAudioContext {
     );
   }
 
-  async close(): Promise<undefined> {
-    await (this.context as IAudioContext).close();
+  async close(): Promise<boolean> {
+    return (this.context as IAudioContext).close();
   }
 
-  async resume(): Promise<undefined> {
-    await (this.context as IAudioContext).resume();
+  async resume(): Promise<boolean> {
+    return (this.context as IAudioContext).resume();
   }
 
-  async suspend(): Promise<undefined> {
-    await (this.context as IAudioContext).suspend();
+  async suspend(): Promise<boolean> {
+    return (this.context as IAudioContext).suspend();
   }
 }

--- a/packages/react-native-audio-api/src/interfaces.ts
+++ b/packages/react-native-audio-api/src/interfaces.ts
@@ -41,9 +41,9 @@ export interface IBaseAudioContext {
 }
 
 export interface IAudioContext extends IBaseAudioContext {
-  close(): Promise<void>;
-  resume(): Promise<void>;
-  suspend(): Promise<void>;
+  close(): Promise<boolean>;
+  resume(): Promise<boolean>;
+  suspend(): Promise<boolean>;
 }
 
 export interface IOfflineAudioContext extends IBaseAudioContext {

--- a/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
+++ b/packages/react-native-audio-api/src/specs/NativeAudioAPIModule.ts
@@ -25,6 +25,7 @@ interface Spec extends TurboModule {
   // Remote commands, system events and interruptions
   enableRemoteCommand(name: string, enabled: boolean): void;
   observeAudioInterruptions(enabled: boolean): void;
+  activelyReclaimSession(enabled: boolean): void;
   observeVolumeChanges(enabled: boolean): void;
 
   // Permissions

--- a/packages/react-native-audio-api/src/system/AudioManager.ts
+++ b/packages/react-native-audio-api/src/system/AudioManager.ts
@@ -57,6 +57,23 @@ class AudioManager {
     NativeAudioAPIModule!.observeAudioInterruptions(enabled);
   }
 
+  /**
+   * @param enabled - Whether to actively reclaim the session or not
+   * @experimental more aggressively try to reactivate the audio session during interruptions.
+   * It is subject to change in the future and might be removed.
+   *
+   * In some cases (depends on app session settings and other apps using audio) system may never
+   * send the `interruption ended` event. This method will check if any other audio is playing
+   * and try to reactivate the audio session, as soon as there is "silence".
+   * Although this might change the expected behavior.
+   *
+   * Internally method uses `AVAudioSessionSilenceSecondaryAudioHintNotification` as well as
+   * interval polling to check if other audio is playing.
+   */
+  activelyReclaimSession(enabled: boolean) {
+    NativeAudioAPIModule!.activelyReclaimSession(enabled);
+  }
+
   observeVolumeChanges(enabled: boolean) {
     NativeAudioAPIModule!.observeVolumeChanges(enabled);
   }


### PR DESCRIPTION
closes RNAA-192

## Introduced changes

<!-- A brief description of the changes -->

- adds experimental function to track if other apps are playing and calling own interruption began and ended events. Usefull for when we want to interrupt locally even when using mixable category and options. It is not ideal, but lets test it until we find better solution for playback and record category with coexistence with f.e. navigation apps.
- properly track and react to interruption and route change events. Previous implementation did track route changes during interruption, but did nothing with it. Currently it will properly mark engine and session as "needs reconfig", this is usefull when category change happened while engine was suspended
- properly track for "is the AVAudioEngine running?", previously during system interruption engine might get paused or tore down, resulting in audio context state returning wrong state ("running") which prevented the user of the lib from restarting the engine properly, additionally to context state engine (and all layers up to context) have its own `isPlaying` state or methods. 
- cleanup of some unnecessary/redundant code

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
