### PR TITLE
fix: hotfixed warning which caused builds to fail

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/utils/CircularOverflowableAudioArray.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/utils/CircularOverflowableAudioArray.h
@@ -16,7 +16,7 @@ namespace audioapi {
 class CircularOverflowableAudioArray : public AudioArray {
  public:
   explicit CircularOverflowableAudioArray(size_t size);
-  CircularOverflowableAudioArray(const CircularOverflowableAudioArray &other) = default;
+  CircularOverflowableAudioArray(const CircularOverflowableAudioArray &other) = delete;
   ~CircularOverflowableAudioArray() = default;
 
   /// @brief Writes data to the circular buffer.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

PR, because react compiles c++ with `-Werror`, which caused this code to fail compilation, because it raised a warning.

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->


## Introduced changes

<!-- A brief description of the changes -->


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
