### PR TITLE
fix: fixed issue with disconnect not happening

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/core/AudioNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/AudioNode.cpp
@@ -49,10 +49,10 @@ void AudioNode::connect(const std::shared_ptr<AudioParam> &param) {
 }
 
 void AudioNode::disconnect() {
-  for (auto it = outputNodes_.begin(), end = outputNodes_.end(); it != end;
-       ++it) {
-    disconnect(*it);
-  }
+  context_->getNodeManager()->addPendingNodeConnection(
+      shared_from_this(),
+      nullptr,
+      AudioNodeManager::ConnectionType::DISCONNECT_ALL);
 }
 
 void AudioNode::disconnect(const std::shared_ptr<AudioNode> &node) {

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.cpp
@@ -57,20 +57,24 @@ void AudioNodeManager::addAudioParam(const std::shared_ptr<AudioParam> &param) {
 }
 
 void AudioNodeManager::settlePendingConnections() {
-  for (auto it = audioNodesToConnect_.begin(), end = audioNodesToConnect_.end();
-       it != end;
-       ++it) {
-    std::shared_ptr<AudioNode> from = std::get<0>(*it);
-    std::shared_ptr<AudioNode> to = std::get<1>(*it);
-    ConnectionType type = std::get<2>(*it);
+  for (int i = 0; i < audioNodesToConnect_.size(); ++i) {
+    auto &connection = audioNodesToConnect_[i];
+    std::shared_ptr<AudioNode> from = std::get<0>(connection);
+    std::shared_ptr<AudioNode> to = std::get<1>(connection);
+    ConnectionType type = std::get<2>(connection);
 
     assert(from != nullptr);
-    assert(to != nullptr);
 
     if (type == ConnectionType::CONNECT) {
+      assert(to != nullptr);
       from->connectNode(to);
-    } else {
+    } else if (type == ConnectionType::DISCONNECT) {
+      assert(to != nullptr);
       from->disconnectNode(to);
+    } else {
+      for (auto &node : from->outputNodes_) {
+        from->disconnectNode(node);
+      }
     }
   }
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/utils/AudioNodeManager.h
@@ -16,7 +16,7 @@ class AudioParam;
 
 class AudioNodeManager {
  public:
-  enum class ConnectionType { CONNECT, DISCONNECT };
+  enum class ConnectionType { CONNECT, DISCONNECT, DISCONNECT_ALL };
   AudioNodeManager() = default;
   ~AudioNodeManager();
 


### PR DESCRIPTION
Introduced new `ConnectionType::DISCONNECT_ALL` which ensures that connection checking happens on the audio thread and some sort of guarantee sequential execution of connect & disconnect

<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-194
Closes 

## ⚠️ Breaking changes ⚠️


## Introduced changes


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web
