### PR TITLE
fix: recorder and audio context issue

### DIFF
--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
@@ -40,7 +40,8 @@
   assert(audioEngine != nil);
   self.sourceNodeId = [audioEngine attachSourceNode:self.sourceNode format:self.format];
 
-  return [audioEngine startIfNecessary];
+  // if the engine is already running we need to restart it to make it use newly attached node
+  return [audioEngine restartAudioEngine];
 }
 
 - (void)stop
@@ -50,6 +51,7 @@
   AudioEngine *audioEngine = [AudioEngine sharedInstance];
   assert(audioEngine != nil);
   [audioEngine detachSourceNodeWithId:self.sourceNodeId];
+  [audioEngine restartAudioEngine];
   [audioEngine stopIfNecessary];
   self.sourceNodeId = nil;
 }

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioPlayer.m
@@ -40,7 +40,13 @@
   assert(audioEngine != nil);
   self.sourceNodeId = [audioEngine attachSourceNode:self.sourceNode format:self.format];
 
-  // if the engine is already running we need to restart it to make it use newly attached node
+  // AudioEngine allows us to attach and connect nodes at runtime but with few limitations
+  // in this case if it is the first player and recorder started the engine we need to restart.
+  // It can be optimized by tracking if we haven't break rules of at runtime modifications from docs
+  // https://developer.apple.com/documentation/avfaudio/avaudioengine?language=objc
+  //
+  // Currently we are restarting because we do not see any significant performance issue and case when
+  // you will need to start and stop player very frequently
   return [audioEngine restartAudioEngine];
 }
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioRecorder.m
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioRecorder.m
@@ -101,7 +101,9 @@
   AudioEngine *audioEngine = [AudioEngine sharedInstance];
   assert(audioEngine != nil);
   [audioEngine attachInputNode:self.sinkNode];
-  [audioEngine startIfNecessary];
+
+  // if the engine is running we need to restart it to make it use newly attached node
+  [audioEngine restartAudioEngine];
 }
 
 - (void)stop
@@ -109,6 +111,7 @@
   AudioEngine *audioEngine = [AudioEngine sharedInstance];
   assert(audioEngine != nil);
   [audioEngine detachInputNode];
+  [audioEngine restartAudioEngine];
   [audioEngine stopIfNecessary];
 }
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioRecorder.m
+++ b/packages/react-native-audio-api/ios/audioapi/ios/core/NativeAudioRecorder.m
@@ -102,7 +102,13 @@
   assert(audioEngine != nil);
   [audioEngine attachInputNode:self.sinkNode];
 
-  // if the engine is running we need to restart it to make it use newly attached node
+  // AudioEngine allows us to attach and connect nodes at runtime but with few limitations
+  // in this case if it is the first recorder node and player started the engine we need to restart.
+  // It can be optimized by tracking if we haven't break rules of at runtime modifications from docs
+  // https://developer.apple.com/documentation/avfaudio/avaudioengine?language=objc
+  //
+  // Currently we are restarting because we do not see any significant performance issue and case when
+  // you will need to start and stop recorder very frequently
   [audioEngine restartAudioEngine];
 }
 


### PR DESCRIPTION
### IOS cause:
audio engine needs to be restarted upon changing anything like attaching detaching nodes.

### Android
Works fine

<!-- Reference any GitHub issues resolved by this PR -->

Closes #598 
Closes #596 

## ⚠️ Breaking changes ⚠️

## Introduced changes

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
