### PR TITLE
[blocked] chore: dropped support for RN 0.75

### DIFF
--- a/packages/audiodocs/docs/other/compatibility.mdx
+++ b/packages/audiodocs/docs/other/compatibility.mdx
@@ -14,7 +14,7 @@ import { Yes, No, Version, Spacer } from '@site/src/components/Compatibility';
 
 |                                     | 0.74  | 0.75  | 0.76  | 0.77  | 0.78  | 0.79  | 0.80  | 0.81  |
 | ----------------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
-| <Version version="nightly"/>        | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>|
+| <Version version="nightly"/>        | <No/> | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>|
 | <Version version="0.7.x"/>          | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <No/> |
 | <Version version="0.6.x"/>          | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <No/> | <No/> |
 | <Version version="0.5.x"/>          | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <No/> | <No/> | <No/> |
@@ -31,7 +31,7 @@ import { Yes, No, Version, Spacer } from '@site/src/components/Compatibility';
 
 |                                     | 0.74  | 0.75  | 0.76  | 0.77  | 0.78  | 0.79  | 0.80  | 0.81  |
 | ----------------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
-| <Version version="nightly"/>        | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>|
+| <Version version="nightly"/>        | <No/> | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>|
 | <Version version="0.7.x"/>          | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <No/> |
 | <Version version="0.6.x"/>          | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <Yes/>| <No/> | <No/> |
 | <Version version="0.5.x"/>          | <No/> | <Yes/>| <Yes/>| <Yes/>| <Yes/>| <No/> | <No/> | <No/> |

--- a/packages/react-native-audio-api/android/build.gradle
+++ b/packages/react-native-audio-api/android/build.gradle
@@ -223,7 +223,7 @@ dependencies {
 
 def assertMinimalReactNativeVersion = task assertMinimalReactNativeVersionTask {
     // If you change the minimal React Native version remember to update Compatibility Table in docs
-    def minimalReactNativeVersion = 75
+    def minimalReactNativeVersion = 76
     onlyIf { REACT_NATIVE_MINOR_VERSION < minimalReactNativeVersion }
     doFirst {
         throw new GradleException("[AudioAPI] Unsupported React Native version. Please use $minimalReactNativeVersion. or newer.")

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/CMakeLists.txt
@@ -39,18 +39,9 @@ set(LINK_LIBRARIES
   oboe::oboe
 )
 
-if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-  set(RN_VERSION_LINK_LIBRARIES
-    ReactAndroid::reactnative
-  )
-else()
-  set(RN_VERSION_LINK_LIBRARIES
-    ReactAndroid::folly_runtime
-    ReactAndroid::react_nativemodule_core
-    ReactAndroid::glog
-    ReactAndroid::reactnativejni
-  )
-endif()
+set(RN_VERSION_LINK_LIBRARIES
+  ReactAndroid::reactnative
+)
 
 target_link_libraries(react-native-audio-api
   ${LINK_LIBRARIES}


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

# Merge only after last 0.7.x release

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- Dropped support for RN 0.75

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
