### PR TITLE
fix: change type to void

### DIFF
--- a/packages/audiodocs/docs/sources/streamer-node.mdx
+++ b/packages/audiodocs/docs/sources/streamer-node.mdx
@@ -7,6 +7,10 @@ import { Optional, ReadOnly } from '@site/src/components/Badges';
 
 # StreamerNode
 
+:::caution
+Mobile only.
+:::
+
 The `StreamerNode` is an [`AudioScheduledSourceNode`](/docs/sources/audio-scheduled-source-node) which represents a node that can decode and play [Http Live Streaming](https://developer.apple.com/streaming/) data.
 Similar to all of `AudioScheduledSourceNodes`, it can be started only once. If you want to play the same sound again you have to create a new one.
 

--- a/packages/react-native-audio-api/src/core/AudioContext.ts
+++ b/packages/react-native-audio-api/src/core/AudioContext.ts
@@ -24,7 +24,7 @@ export default class AudioContext extends BaseAudioContext {
     );
   }
 
-  async close(): Promise<boolean> {
+  async close(): Promise<void> {
     return (this.context as IAudioContext).close();
   }
 

--- a/packages/react-native-audio-api/src/interfaces.ts
+++ b/packages/react-native-audio-api/src/interfaces.ts
@@ -42,7 +42,7 @@ export interface IBaseAudioContext {
 }
 
 export interface IAudioContext extends IBaseAudioContext {
-  close(): Promise<boolean>;
+  close(): Promise<void>;
   resume(): Promise<boolean>;
   suspend(): Promise<boolean>;
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #638

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- changed type of promise from boolean to void in close method of AudioContext
- added mention about streamer node being mobile only in docs

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
