### PR TITLE
fix: add optional path prefix to LoadCustomWasm

### DIFF
--- a/packages/react-native-audio-api/src/web-core/custom/LoadCustomWasm.ts
+++ b/packages/react-native-audio-api/src/web-core/custom/LoadCustomWasm.ts
@@ -3,7 +3,7 @@ const eventTitle = 'rnaaCstStretchLoaded';
 
 export let globalWasmPromise: Promise<void> | null = null;
 
-const LoadCustomWasm = async () => {
+const LoadCustomWasm = async (pathPrefix: string = '') => {
   if (typeof window === 'undefined') {
     return null;
   }
@@ -18,7 +18,7 @@ const LoadCustomWasm = async () => {
     loadScript.type = 'module';
 
     loadScript.textContent = `
-      import SignalsmithStretch from '/signalsmithStretch.mjs';
+      import SignalsmithStretch from '${pathPrefix}/signalsmithStretch.mjs';
       window.${globalTag} = SignalsmithStretch;
       window.postMessage('${eventTitle}');
     `;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->


## ⚠️ Breaking changes ⚠️



-

## Introduced changes

<!-- A brief description of the changes -->

- Added an optional path prefix to `LoadCustomWasm.ts`, this allows us to properly load `signalsmithStretch` script from our docs

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
