### PR TITLE
fix: changed 'onended' property to 'onEnded' for consistency

### DIFF
--- a/apps/common-app/src/examples/AudioFile/AudioPlayer.ts
+++ b/apps/common-app/src/examples/AudioFile/AudioPlayer.ts
@@ -58,6 +58,7 @@ class AudioPlayer {
 
     this.sourceNode.start(this.audioContext.currentTime, this.offset);
 
+
     AudioManager.setLockScreenInfo({
       state: 'state_playing',
     });

--- a/apps/common-app/src/examples/AudioFile/AudioPlayer.ts
+++ b/apps/common-app/src/examples/AudioFile/AudioPlayer.ts
@@ -58,7 +58,6 @@ class AudioPlayer {
 
     this.sourceNode.start(this.audioContext.currentTime, this.offset);
 
-
     AudioManager.setLockScreenInfo({
       state: 'state_playing',
     });

--- a/packages/audiodocs/src/audio/AudioManager.ts
+++ b/packages/audiodocs/src/audio/AudioManager.ts
@@ -195,7 +195,7 @@ class AudioManager {
     source.buffer = buffer;
     source.loop = loop;
 
-    source.onended = this.onSoundEnded.bind(this, { id, onEnded });
+    source.onEnded = this.onSoundEnded.bind(this, { id, onEnded });
 
     const gainNode = this.aCtx.createGain();
     gainNode.gain.value = volume;
@@ -228,7 +228,7 @@ class AudioManager {
         return;
       }
 
-      source.sourceNode.onended = this.onSoundEnded.bind(this, {
+      source.sourceNode.onEnded = this.onSoundEnded.bind(this, {
         id,
         onEnded: () => { resolve(); },
       });

--- a/packages/audiodocs/src/audio/MockAudioContext.ts
+++ b/packages/audiodocs/src/audio/MockAudioContext.ts
@@ -20,7 +20,7 @@ const MockAudioContext = {
     connect: () => {},
     start: () => {},
     stop: () => {},
-    onended: null,
+    onEnded: null,
   }),
   currentTime: 0,
   decodeAudioData: (data: ArrayBuffer) => Promise.resolve({

--- a/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioScheduledSourceNode.ts
@@ -10,7 +10,7 @@ export default class AudioScheduledSourceNode extends AudioNode {
     global.AudioEventEmitter
   );
 
-  private onendedSubscription?: AudioEventSubscription;
+  private onEndedSubscription?: AudioEventSubscription;
   private onEndedCallback?: (event: OnEndedEventType) => void;
 
   public start(when: number = 0): void {
@@ -51,19 +51,19 @@ export default class AudioScheduledSourceNode extends AudioNode {
   public set onEnded(callback: ((event: OnEndedEventType) => void) | null) {
     if (!callback) {
       (this.node as IAudioScheduledSourceNode).onEnded = '0';
-      this.onendedSubscription?.remove();
-      this.onendedSubscription = undefined;
+      this.onEndedSubscription?.remove();
+      this.onEndedSubscription = undefined;
       this.onEndedCallback = undefined;
       return;
     }
 
     this.onEndedCallback = callback;
-    this.onendedSubscription = this.audioEventEmitter.addAudioEventListener(
+    this.onEndedSubscription = this.audioEventEmitter.addAudioEventListener(
       'ended',
       callback
     );
 
     (this.node as IAudioScheduledSourceNode).onEnded =
-      this.onendedSubscription.subscriptionId;
+      this.onEndedSubscription.subscriptionId;
   }
 }

--- a/packages/react-native-audio-api/src/web-core/AudioBufferSourceNode.tsx
+++ b/packages/react-native-audio-api/src/web-core/AudioBufferSourceNode.tsx
@@ -26,7 +26,7 @@ interface IStretcherNode extends globalThis.AudioNode {
   numberOfInputs: number;
   numberOfOutputs: number;
 
-  onended:
+  onEnded:
     | ((this: globalThis.AudioScheduledSourceNode, ev: Event) => unknown)
     | null;
   addEventListener: (

--- a/packages/react-native-audio-api/src/web-core/AudioScheduledSourceNode.tsx
+++ b/packages/react-native-audio-api/src/web-core/AudioScheduledSourceNode.tsx
@@ -37,7 +37,7 @@ export default class AudioScheduledSourceNode extends AudioNode {
   }
 
   // eslint-disable-next-line accessor-pairs
-  public set onended(callback: (event: EventEmptyType) => void) {
-    (this.node as globalThis.AudioScheduledSourceNode).onended = callback;
+  public set onEnded(callback: (event: EventEmptyType) => void) {
+    (this.node as globalThis.AudioScheduledSourceNode).onEnded = callback;
   }
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- **Event handler property renamed:** `onended` property has been renamed to `onEnded` across all AudioScheduledSourceNode implementations
- **API change:** Existing code using audioSourceNode.onended must be updated to use audioSourceNode.onEnded
- **Affects**: AudioScheduledSourceNode, AudioBufferSourceNode, and related audio source components

## Introduced changes

- Standardized event handler naming convention from onended to onEnded for consistent camelCase formatting
- Updated AudioScheduledSourceNode implementations across native and web platforms
- Applied consistent naming in AudioManager and MockAudioContext
- Improved API consistency between native iOS/Android and web implementations
- Enhanced code maintainability through unified naming conventions

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
