### PR TITLE
Fix: correct param initialization on play in AudioBufferSource interactive playground

### DIFF
--- a/packages/audiodocs/src/components/InteractivePlayground/AudioBufferSourceExample/AudioBufferSourceExample.tsx
+++ b/packages/audiodocs/src/components/InteractivePlayground/AudioBufferSourceExample/AudioBufferSourceExample.tsx
@@ -41,14 +41,6 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
   const audioBufferRef = useRef<AudioBuffer | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
 
-  const audioPropsRef = useRef({
-    playbackRate,
-    detune,
-    loop,
-    loopStart,
-    loopEnd,
-  });
-
   const stopSound = useCallback(() => {
     if (bufferSourceRef.current) {
       bufferSourceRef.current.onEnded = null; // Prevent onEnded from firing on manual stop
@@ -67,14 +59,6 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
     if (bufferSourceRef.current) {
       stopSound();
     }
-    
-    const {
-      playbackRate,
-      detune,
-      loop,
-      loopStart,
-      loopEnd,
-    } = audioPropsRef.current;
 
     const source = await ctx.createBufferSource({
       pitchCorrection: pitchCorrection,
@@ -99,7 +83,7 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
         setIsPlaying(false);
       }
     };
-  }, [stopSound]); 
+  }, [stopSound, playbackRate,detune,loop,loopStart,loopEnd, pitchCorrection]); 
 
   const handlePlayButtonClick = () => {
     if (isPlaying) {
@@ -108,16 +92,6 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
       playSound();
     }
   };
-
-  useEffect(() => {
-    audioPropsRef.current = {
-      playbackRate,
-      detune,
-      loop,
-      loopStart,
-      loopEnd,
-    };
-  }, [playbackRate, detune, loop, loopStart, loopEnd]);
 
   useEffect(() => {
     let mounted = true;
@@ -162,15 +136,26 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
   }, [pitchCorrection]);
 
   useEffect(() => {
-    if (!bufferSourceRef.current) {
+    const source = bufferSourceRef.current;
+    const ctx = audioContextRef.current;
+    if (!source || !ctx) {
       return;
     }
 
-    bufferSourceRef.current.playbackRate.value = playbackRate;
-    bufferSourceRef.current.detune.value = detune;
-    bufferSourceRef.current.loop = loop;
-    bufferSourceRef.current.loopStart = loopStart;
-    bufferSourceRef.current.loopEnd = loopEnd;
+    const RAMP_TIME = 0.05; 
+
+    source.playbackRate.setValueAtTime(
+      playbackRate,
+      ctx.currentTime + RAMP_TIME
+    );
+    source.detune.setValueAtTime(
+      detune,
+      ctx.currentTime + RAMP_TIME
+    );
+ 
+    source.loop = loop;
+    source.loopStart = loopStart;
+    source.loopEnd = loopEnd;
   }, [playbackRate, detune, loop, loopStart, loopEnd]);
 
   return (

--- a/packages/audiodocs/src/components/InteractivePlayground/AudioBufferSourceExample/AudioBufferSourceExample.tsx
+++ b/packages/audiodocs/src/components/InteractivePlayground/AudioBufferSourceExample/AudioBufferSourceExample.tsx
@@ -41,6 +41,14 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
   const audioBufferRef = useRef<AudioBuffer | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
 
+  const audioPropsRef = useRef({
+    playbackRate,
+    detune,
+    loop,
+    loopStart,
+    loopEnd,
+  });
+
   const stopSound = useCallback(() => {
     if (bufferSourceRef.current) {
       bufferSourceRef.current.onEnded = null; // Prevent onEnded from firing on manual stop
@@ -59,12 +67,26 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
     if (bufferSourceRef.current) {
       stopSound();
     }
+    
+    const {
+      playbackRate,
+      detune,
+      loop,
+      loopStart,
+      loopEnd,
+    } = audioPropsRef.current;
 
     const source = await ctx.createBufferSource({
       pitchCorrection: pitchCorrection,
     });
 
     source.buffer = audioBufferRef.current;
+    source.playbackRate.value = playbackRate;
+    source.detune.value = detune;
+    source.loop = loop;
+    source.loopStart = loopStart;
+    source.loopEnd = loopEnd;
+
     await ctx.resume();
     source.connect(analyserRef.current!);
     source.start();
@@ -77,7 +99,7 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
         setIsPlaying(false);
       }
     };
-  }, [stopSound]);
+  }, [stopSound]); 
 
   const handlePlayButtonClick = () => {
     if (isPlaying) {
@@ -86,6 +108,16 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
       playSound();
     }
   };
+
+  useEffect(() => {
+    audioPropsRef.current = {
+      playbackRate,
+      detune,
+      loop,
+      loopStart,
+      loopEnd,
+    };
+  }, [playbackRate, detune, loop, loopStart, loopEnd]);
 
   useEffect(() => {
     let mounted = true;
@@ -127,7 +159,7 @@ const AudioBufferSourceExample: FC<AudioBufferSourceExampleProps> = (props) => {
       stopSound();
       playSound();
     }
-  }, [pitchCorrection, stopSound, playSound, isPlaying]);
+  }, [pitchCorrection]);
 
   useEffect(() => {
     if (!bufferSourceRef.current) {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes 

## ⚠️ Breaking changes ⚠️

## Introduced changes

<!-- A brief description of the changes -->

- added correct param initialization when playing the sample in 'AudioBufferSourceExample' so it always starts with correct parameters chosen by the user

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
