### PR TITLE
Fix iOS compilation for custom audio processor implementations

### DIFF
--- a/packages/react-native-audio-api/RNAudioAPI.podspec
+++ b/packages/react-native-audio-api/RNAudioAPI.podspec
@@ -20,12 +20,12 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/software-mansion/react-native-audio-api.git", :tag => "#{s.version}" }
 
   s.subspec "audioapi" do |ss|
-    ss.source_files = "common/cpp/audioapi/**/*.{cpp,c,h}"
+    ss.source_files = "common/cpp/audioapi/**/*.{cpp,c,h,hpp}"
     ss.header_dir = "audioapi"
     ss.header_mappings_dir = "common/cpp/audioapi"
 
     ss.subspec "ios" do |sss|
-      sss.source_files = "ios/audioapi/**/*.{mm,h,m}"
+      sss.source_files = "ios/audioapi/**/*.{mm,h,m,hpp}"
       sss.header_dir = "audioapi"
       sss.header_mappings_dir = "ios/audioapi"
     end
@@ -42,8 +42,10 @@ Pod::Spec.new do |s|
   # Assumes Pods dir is nested under ios project dir
   ios_dir = File.join(Pod::Config.instance.project_pods_root, '..')
   rn_audio_dir_relative = Pathname.new(__dir__).relative_path_from(ios_dir).to_s
-  external_dir = "common/cpp/audioapi/external"
-  lib_dir = "$(PROJECT_DIR)/#{rn_audio_dir_relative}/#{external_dir}/$(PLATFORM_NAME)"
+  external_dir_relative = "common/cpp/audioapi/external"
+  lib_dir = "$(PROJECT_DIR)/#{rn_audio_dir_relative}/#{external_dir_relative}/$(PLATFORM_NAME)"
+  
+  external_dir = File.join(__dir__, "common/cpp/audioapi/external")
   
   s.ios.vendored_frameworks = [
     'common/cpp/audioapi/external/libavcodec.xcframework',
@@ -59,9 +61,9 @@ s.pod_target_xcconfig = {
   "HEADER_SEARCH_PATHS" => %W[
     $(PODS_TARGET_SRCROOT)/common/cpp
     $(PODS_TARGET_SRCROOT)/ios
-    $(PODS_TARGET_SRCROOT)/#{external_dir}/include
-    $(PODS_TARGET_SRCROOT)/#{external_dir}/include/opus
-    $(PODS_TARGET_SRCROOT)/#{external_dir}/include/vorbis
+    $(PODS_TARGET_SRCROOT)/#{external_dir_relative}/include
+    $(PODS_TARGET_SRCROOT)/#{external_dir_relative}/include/opus
+    $(PODS_TARGET_SRCROOT)/#{external_dir_relative}/include/vorbis
     $(PODS_TARGET_SRCROOT)/common/cpp/audioapi/external/ffmpeg_include
   ].join(" "),
   'OTHER_CFLAGS' => "$(inherited) #{folly_flags} #{fabric_flags} #{version_flag}"
@@ -76,7 +78,14 @@ s.user_target_xcconfig = {
     -force_load #{lib_dir}/libvorbis.a
     -force_load #{lib_dir}/libvorbisenc.a
     -force_load #{lib_dir}/libvorbisfile.a
-  ].join(" ")
+  ].join(" "),
+  'HEADER_SEARCH_PATHS' => %W[
+    $(inherited)
+    #{external_dir}/ffmpeg_include
+    #{external_dir}/include
+    $(PODS_TARGET_SRCROOT)/common/cpp
+    $(PODS_ROOT)/Headers/Public/RNAudioAPI
+  ].join(' ')
 }
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
Problem
The react-native-audio-api library works perfectly for standard usage. However, when implementing custom audio processors using TurboModules (advanced use case), iOS compilation fails with:
•  'libavformat/avformat.h' file not found
•  'audioapi/utils/RingBiDirectionalBuffer.hpp' file not found

These errors occur during npx expo run:ios when custom processor files are compiled in the app target context.

Root Cause
1. Template library headers (.hpp files) weren't included in podspec source patterns
2. FFmpeg headers were only accessible to pod target, not app target where custom processors compile

Solution
•  Add .hpp extension to source_files patterns for template headers
•  Add HEADER_SEARCH_PATHS to user_target_xcconfig for app target
•  Fixes compilation errors when implementing custom TurboModule audio processors
•  Resolves 'libavformat/avformat.h' and '.hpp file not found' errors
•  Normal react-native-audio-api usage unaffected

Testing
•  ✅ Standard library usage continues to work
•  ✅ Custom audio processor implementations now compile successfully
•  ✅ Maintains compatibility with PR #666 portability improvements

This fix specifically addresses the advanced use case of custom audio processor development without affecting regular library usage.