### PR TITLE
feat: async promise resolving

### DIFF
--- a/packages/react-native-audio-api/common/cpp/audioapi/jsi/JsiPromise.h
+++ b/packages/react-native-audio-api/common/cpp/audioapi/jsi/JsiPromise.h
@@ -2,6 +2,8 @@
 
 #include <ReactCommon/CallInvoker.h>
 #include <jsi/jsi.h>
+#include <variant>
+#include <thread>
 #include <memory>
 #include <string>
 #include <utility>
@@ -33,6 +35,23 @@ class PromiseVendor {
   PromiseVendor(jsi::Runtime *runtime, const std::shared_ptr<react::CallInvoker> &callInvoker): runtime_(runtime), callInvoker_(callInvoker) {}
 
   jsi::Value createPromise(const std::function<void(std::shared_ptr<Promise>)> &function);
+
+  /// @brief Creates an asynchronous promise.
+  /// @param function The function to execute asynchronously. It should return either a jsi::Value on success or a std::string error message on failure.
+  /// @return The created promise.
+  /// @note The function is executed on a different thread, and the promise is resolved or rejected based on the function's outcome.
+  /// @example
+  /// ```cpp
+  /// auto promise = promiseVendor_->createAsyncPromise(
+  ///     [](jsi::Runtime& rt) -> std::variant<jsi::Value, std::string> {
+  ///    // Simulate some heavy work
+  ///    std::this_thread::sleep_for(std::chrono::seconds(2));
+  ///    return jsi::String::createFromUtf8(rt, "Promise resolved successfully!");
+  ///  }
+  /// );
+  ///
+  /// return promise;
+  jsi::Value createAsyncPromise(std::function<std::variant<jsi::Value, std::string>(jsi::Runtime&)> &&function);
 
  private:
   jsi::Runtime *runtime_;


### PR DESCRIPTION
Implemented method that simplifies creating promises that are heavy and should be resolved on separate thread. It also creates a room for adding thread pool in a future.

## ⚠️ Breaking changes ⚠️

## Introduced changes

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
