### PR TITLE
Feat/audio buffer queue source node/extened on ended event payload

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -3081,7 +3081,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: c91900fa724baee992f01c05eeb4c9e01a807f78
   ReactCodegen: 8125d6ee06ea06f48f156cbddec5c2ca576d62e6
   ReactCommon: 116d6ee71679243698620d8cd9a9042541e44aa6
-  RNAudioAPI: f483edfc07b2343174d27a99e9e40d8b89ca33d1
+  RNAudioAPI: 33e9940fd9e8b3694107f461a45fe23eb40c652b
   RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
   RNReanimated: a035264789d1f64cb5adba7085d6aac6e9ec70a7
   RNScreens: 6ced6ae8a526512a6eef6e28c2286e1fc2d378c3

--- a/packages/audiodocs/docs/sources/audio-buffer-queue-source-node.mdx
+++ b/packages/audiodocs/docs/sources/audio-buffer-queue-source-node.mdx
@@ -85,8 +85,9 @@ Removes all buffers from the queue. Note that `onEnded` event will not be fired 
 
 ### `onEnded` <Overridden />
 
-Sets (or remove) callback that will be fired when queue source node has been stopped with payload `event.bufferId = undefined`
-or when a specific buffer has ended with payload `event.bufferId = <bufferId>`.
+Sets (or remove) callback that will be fired when queue source node has been stopped with payload `{ bufferId: undefined, isLast: undefined }`
+or when a specific buffer has ended with payload `{ bufferId: <bufferId>, isLast: <isLast> }`,
+where `bufferId` is the ID of the buffer that has ended and `isLast` is a boolean indicating whether it was the last buffer in the queue.
 
 You can remove callback by passing `null`.
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
@@ -155,9 +155,7 @@ void AudioBufferQueueSourceNode::processWithoutInterpolation(
       buffers_.pop();
 
       std::unordered_map<std::string, EventValue> body = {
-          {"bufferId", std::to_string(bufferId)},
-          {"isLast", buffers_.empty()}
-      };
+          {"bufferId", std::to_string(bufferId)}, {"isLast", buffers_.empty()}};
       context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
           "ended", onEndedCallbackId_, body);
 

--- a/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
+++ b/packages/react-native-audio-api/common/cpp/audioapi/core/sources/AudioBufferQueueSourceNode.cpp
@@ -155,7 +155,9 @@ void AudioBufferQueueSourceNode::processWithoutInterpolation(
       buffers_.pop();
 
       std::unordered_map<std::string, EventValue> body = {
-          {"bufferId", std::to_string(bufferId)}};
+          {"bufferId", std::to_string(bufferId)},
+          {"isLast", buffers_.empty()}
+      };
       context_->audioEventHandlerRegistry_->invokeHandlerWithEventBody(
           "ended", onEndedCallbackId_, body);
 

--- a/packages/react-native-audio-api/src/core/OscillatorNode.ts
+++ b/packages/react-native-audio-api/src/core/OscillatorNode.ts
@@ -5,6 +5,7 @@ import AudioParam from './AudioParam';
 import BaseAudioContext from './BaseAudioContext';
 import PeriodicWave from './PeriodicWave';
 import { InvalidStateError } from '../errors';
+import { EventEmptyType } from '../events/types';
 
 export default class OscillatorNode extends AudioScheduledSourceNode {
   readonly frequency: AudioParam;
@@ -33,5 +34,15 @@ export default class OscillatorNode extends AudioScheduledSourceNode {
 
   public setPeriodicWave(wave: PeriodicWave): void {
     (this.node as IOscillatorNode).setPeriodicWave(wave.periodicWave);
+  }
+
+  public override get onEnded(): ((event: EventEmptyType) => void) | undefined {
+    return super.onEnded as ((event: EventEmptyType) => void) | undefined;
+  }
+
+  public override set onEnded(
+    callback: ((event: EventEmptyType) => void) | null
+  ) {
+    super.onEnded = callback;
   }
 }

--- a/packages/react-native-audio-api/src/events/types.ts
+++ b/packages/react-native-audio-api/src/events/types.ts
@@ -46,6 +46,7 @@ type SystemEvents = RemoteCommandEvents & {
 
 export interface OnEndedEventType extends EventEmptyType {
   bufferId: string | undefined;
+  isLast: boolean | undefined;
 }
 
 export interface OnAudioReadyEventType {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes RNAA-223

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

-

## Introduced changes

<!-- A brief description of the changes -->

- Added `isLast` property to onEnded event payload in `AudioBufferQueueSourceNode` indicating if it was the last buffer in the queue

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
