### PR TITLE
fix: trivial tests for more accurate coverage

### DIFF
--- a/packages/react-native-audio-api/common/cpp/test/RunCoverage.sh
+++ b/packages/react-native-audio-api/common/cpp/test/RunCoverage.sh
@@ -76,7 +76,7 @@ coverage_report="$("$LLVM_COV" report \
   --instr-profile="$PROFDATA_FILE" \
   --ignore-filename-regex="$IGNORE_FILENAME_REGEX")"
 
-echo "$coverage_report"
+echo "$coverage_report" | tee "$BUILD_DIR/llvm-cov-report.txt"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   {

--- a/packages/react-native-audio-api/common/cpp/test/src/core/analysis/AnalyserNodeTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/analysis/AnalyserNodeTest.cpp
@@ -10,7 +10,9 @@ namespace audioapi::test {
 
 TEST(AnalyserNodeTest, TrivialConstruct) {
   auto registry = std::make_shared<MockAudioEventHandlerRegistry>();
-  auto context = std::make_shared<OfflineAudioContext>(2, 128, 44100.0f, registry);
+  constexpr size_t LENGTH = 128;
+  constexpr float SAMPLE_RATE = 44100.0f;
+  auto context = std::make_shared<OfflineAudioContext>(2, LENGTH, SAMPLE_RATE, registry);
   AnalyserNode analyser(context, AnalyserOptions{});
   EXPECT_EQ(analyser.getFFTSize(), AnalyserOptions::kDefaultFftSize);
 }

--- a/packages/react-native-audio-api/common/cpp/test/src/core/analysis/AnalyserNodeTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/analysis/AnalyserNodeTest.cpp
@@ -1,0 +1,18 @@
+#include <audioapi/core/OfflineAudioContext.h>
+#include <audioapi/core/analysis/AnalyserNode.h>
+#include <audioapi/types/NodeOptions.h>
+#include <gtest/gtest.h>
+#include <test/src/MockAudioEventHandlerRegistry.h>
+
+#include <memory>
+
+namespace audioapi::test {
+
+TEST(AnalyserNodeTest, TrivialConstruct) {
+  auto registry = std::make_shared<MockAudioEventHandlerRegistry>();
+  auto context = std::make_shared<OfflineAudioContext>(2, 128, 44100.0f, registry);
+  AnalyserNode analyser(context, AnalyserOptions{});
+  EXPECT_EQ(analyser.getFFTSize(), AnalyserOptions::kDefaultFftSize);
+}
+
+} // namespace audioapi::test

--- a/packages/react-native-audio-api/common/cpp/test/src/core/analysis/AnalyserNodeTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/analysis/AnalyserNodeTest.cpp
@@ -8,6 +8,7 @@
 
 namespace audioapi::test {
 
+// TODO: replace this testcase with more meaningful ones.
 TEST(AnalyserNodeTest, TrivialConstruct) {
   auto registry = std::make_shared<MockAudioEventHandlerRegistry>();
   constexpr size_t LENGTH = 128;

--- a/packages/react-native-audio-api/common/cpp/test/src/core/sources/RecorderAdapterNodeTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/sources/RecorderAdapterNodeTest.cpp
@@ -1,0 +1,18 @@
+#include <audioapi/core/OfflineAudioContext.h>
+#include <audioapi/core/sources/RecorderAdapterNode.h>
+#include <gtest/gtest.h>
+#include <test/src/MockAudioEventHandlerRegistry.h>
+
+#include <memory>
+
+namespace audioapi::test {
+
+TEST(RecorderAdapterNodeTest, TrivialConstructAndInit) {
+  auto registry = std::make_shared<MockAudioEventHandlerRegistry>();
+  auto context = std::make_shared<OfflineAudioContext>(2, 128, 44100.0f, registry);
+  RecorderAdapterNode adapter(context);
+  adapter.init(256, 1, 44100.0f);
+  adapter.adapterCleanup();
+}
+
+} // namespace audioapi::test

--- a/packages/react-native-audio-api/common/cpp/test/src/core/sources/RecorderAdapterNodeTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/sources/RecorderAdapterNodeTest.cpp
@@ -7,6 +7,7 @@
 
 namespace audioapi::test {
 
+// TODO: replace this testcase with more meaningful ones.
 TEST(RecorderAdapterNodeTest, TrivialConstructAndInit) {
   auto registry = std::make_shared<MockAudioEventHandlerRegistry>();
   auto context = std::make_shared<OfflineAudioContext>(2, 128, 44100.0f, registry);

--- a/packages/react-native-audio-api/common/cpp/test/src/core/utils/RotatingFileWriterTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/utils/RotatingFileWriterTest.cpp
@@ -1,0 +1,13 @@
+#include <audioapi/core/utils/RotatingFileWriter.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace audioapi::test {
+
+TEST(RotatingFileWriterTest, TrivialConstruct) {
+  RotatingFileWriter writer(1024, [](const auto &) { return nullptr; }, [](const std::string &) {});
+  SUCCEED();
+}
+
+} // namespace audioapi::test

--- a/packages/react-native-audio-api/common/cpp/test/src/core/utils/RotatingFileWriterTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/utils/RotatingFileWriterTest.cpp
@@ -5,6 +5,7 @@
 
 namespace audioapi::test {
 
+// TODO: replace this testcase with more meaningful ones.
 TEST(RotatingFileWriterTest, TrivialConstruct) {
   RotatingFileWriter writer(1024, [](const auto &) { return nullptr; }, [](const std::string &) {});
   SUCCEED();

--- a/packages/react-native-audio-api/common/cpp/test/src/core/utils/param/ParamControlQueueTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/utils/param/ParamControlQueueTest.cpp
@@ -1,0 +1,15 @@
+#include <audioapi/core/types/ParamEventType.h>
+#include <audioapi/core/utils/param/ParamControlQueue.h>
+#include <audioapi/core/utils/param/ParamEvent.h>
+#include <gtest/gtest.h>
+
+namespace audioapi::test {
+
+TEST(ParamControlQueueTest, TrivialConstructAndPurge) {
+  ParamControlQueue queue;
+  ParamEvent event(ParamEventType::SET_VALUE, 0.0);
+  EXPECT_TRUE(queue.checkCurveExclusion(event).is_ok());
+  queue.purge(0.0);
+}
+
+} // namespace audioapi::test

--- a/packages/react-native-audio-api/common/cpp/test/src/core/utils/param/ParamControlQueueTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/core/utils/param/ParamControlQueueTest.cpp
@@ -5,6 +5,7 @@
 
 namespace audioapi::test {
 
+// TODO: replace this testcase with more meaningful ones.
 TEST(ParamControlQueueTest, TrivialConstructAndPurge) {
   ParamControlQueue queue;
   ParamEvent event(ParamEventType::SET_VALUE, 0.0);

--- a/packages/react-native-audio-api/common/cpp/test/src/graph/HostNodeTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/graph/HostNodeTest.cpp
@@ -1,0 +1,17 @@
+#include <audioapi/core/utils/Disposer.hpp>
+#include <audioapi/core/utils/graph/Graph.h>
+#include <gtest/gtest.h>
+#include <test/src/graph/TestGraphUtils.h>
+
+#include <memory>
+
+namespace audioapi::test {
+
+TEST(HostNodeTest, TrivialConstruct) {
+  utils::DisposerImpl<audioapi::DISPOSER_PAYLOAD_SIZE> disposer{64};
+  auto graph = std::make_shared<utils::graph::Graph>(64, &disposer);
+  utils::graph::MockHostNode node(graph);
+  EXPECT_NE(node.rawNode(), nullptr);
+}
+
+} // namespace audioapi::test

--- a/packages/react-native-audio-api/common/cpp/test/src/graph/HostNodeTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/graph/HostNodeTest.cpp
@@ -7,6 +7,7 @@
 
 namespace audioapi::test {
 
+// TODO: replace this testcase with more meaningful ones.
 TEST(HostNodeTest, TrivialConstruct) {
   utils::DisposerImpl<audioapi::DISPOSER_PAYLOAD_SIZE> disposer{64};
   auto graph = std::make_shared<utils::graph::Graph>(64, &disposer);

--- a/packages/react-native-audio-api/common/cpp/test/src/utils/CircularOverflowableAudioArrayTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/utils/CircularOverflowableAudioArrayTest.cpp
@@ -1,0 +1,22 @@
+#include <audioapi/utils/CircularOverflowableAudioArray.h>
+#include <gtest/gtest.h>
+
+#include <array>
+
+namespace audioapi::test {
+
+TEST(CircularOverflowableAudioArrayTest, WriteThenReadRoundTrips) {
+  constexpr size_t kCapacity = 8;
+  constexpr size_t kFrames = 4;
+
+  CircularOverflowableAudioArray buffer(kCapacity);
+  const std::array<float, kFrames> input = {1.0f, 2.0f, 3.0f, 4.0f};
+
+  buffer.write(input.data(), kFrames);
+
+  std::array<float, kFrames> output = {};
+  EXPECT_EQ(buffer.read(output.data(), kFrames), kFrames);
+  EXPECT_EQ(output, input);
+}
+
+} // namespace audioapi::test

--- a/packages/react-native-audio-api/common/cpp/test/src/utils/CircularOverflowableAudioArrayTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/utils/CircularOverflowableAudioArrayTest.cpp
@@ -5,6 +5,7 @@
 
 namespace audioapi::test {
 
+// TODO: replace this testcase with more meaningful ones.
 TEST(CircularOverflowableAudioArrayTest, WriteThenReadRoundTrips) {
   constexpr size_t kCapacity = 8;
   constexpr size_t kFrames = 4;

--- a/packages/react-native-audio-api/common/cpp/test/src/utils/ThreadPoolTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/utils/ThreadPoolTest.cpp
@@ -1,0 +1,18 @@
+#include <audioapi/utils/ThreadPool.hpp>
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+namespace audioapi::test {
+
+TEST(ThreadPoolTest, ScheduleRunsTaskAndWaitReturns) {
+  std::atomic<int> counter{0};
+  ThreadPool<thread_pool::kSmallTaskStorageBytes> pool(2, 8, 8);
+
+  pool.schedule([&counter]() { counter.fetch_add(1, std::memory_order_relaxed); });
+  pool.wait();
+
+  EXPECT_EQ(counter.load(std::memory_order_relaxed), 1);
+}
+
+} // namespace audioapi::test

--- a/packages/react-native-audio-api/common/cpp/test/src/utils/ThreadPoolTest.cpp
+++ b/packages/react-native-audio-api/common/cpp/test/src/utils/ThreadPoolTest.cpp
@@ -5,6 +5,7 @@
 
 namespace audioapi::test {
 
+// TODO: replace this testcase with more meaningful ones.
 TEST(ThreadPoolTest, ScheduleRunsTaskAndWaitReturns) {
   std::atomic<int> counter{0};
   ThreadPool<thread_pool::kSmallTaskStorageBytes> pool(2, 8, 8);


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- None

## Introduced changes

<!-- A brief description of the changes -->

- Add trivial C++ gtests so previously unlinked modules appear in the llvm-cov report: `AnalyserNode`, `RecorderAdapterNode`, `RotatingFileWriter`, `ParamControlQueue`, `HostNode`, `CircularOverflowableAudioArray`, `ThreadPool`.
- Only a few such coverage-visibility tests were added where feasible without JSI / HostObject dependencies (e.g. `AudioEventHandlerRegistry`, `AudioRecorder`, `AudioFileWriter`, `AudioRecorderCallback`, `AudioFileProperties` were left out).

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>