### PR TITLE
docs: add privacy policy link to footer

### DIFF
--- a/packages/audiodocs/docusaurus.config.js
+++ b/packages/audiodocs/docusaurus.config.js
@@ -120,7 +120,8 @@ const config = {
     },
     footer: {
       links: [],
-      copyright: `All trademarks and copyrights belong to their respective owners.`,
+      copyright:
+        'All trademarks and copyrights belong to their respective owners. Read about our ',
     },
     prism: {
       additionalLanguages: ['bash', 'cmake'],

--- a/packages/audiodocs/src/css/overrides.css
+++ b/packages/audiodocs/src/css/overrides.css
@@ -23,7 +23,7 @@
 }
 
 footer.footer {
-  --ifm-footer-padding-vertical: 40px;
+  --ifm-footer-padding-vertical: 32px;
 }
 
 @media (max-width: 996px) {

--- a/packages/audiodocs/src/css/overrides.css
+++ b/packages/audiodocs/src/css/overrides.css
@@ -22,6 +22,42 @@
   z-index: 100;
 }
 
+footer.footer {
+  --ifm-footer-padding-vertical: 40px;
+}
+
+@media (max-width: 996px) {
+  footer.footer {
+    --ifm-footer-padding-vertical: 20px;
+  }
+}
+
+@media (max-width: 768px) {
+  footer.footer {
+    --ifm-footer-padding-vertical: 20px;
+  }
+}
+
+footer .footer__bottom [class*='footer__copyright'] {
+  justify-content: center;
+  padding-bottom: var(--swm-footer-copyright-padding-bottom);
+}
+
+footer .footer__bottom [class*='footer__copyright'] p {
+  text-align: center;
+}
+
+footer .footer__bottom [class*='footer__copyright'] a,
+footer .footer__bottom [class*='footer__copyright'] a:hover {
+  text-decoration: none;
+}
+
+@media (max-width: 996px) {
+  footer .footer__bottom [class*='footer__copyright'] {
+    align-items: center;
+  }
+}
+
 .docusaurus-mermaid-container {
   display: flex;
   justify-content: center;

--- a/packages/audiodocs/src/landingComponents/FooterBackground/styles.module.css
+++ b/packages/audiodocs/src/landingComponents/FooterBackground/styles.module.css
@@ -1,6 +1,6 @@
 .container {
   position: relative;
-  margin-top: 106px;
+  margin-top: 122px;
 }
 
 .footerBg {
@@ -20,12 +20,12 @@
 }
 
 [class*='footerLanding'] {
-  margin-top: -106px;
+  margin-top: -115px;
 }
 
 @media (max-width: 996px) {
   .container {
-    margin-top: 121px;
+    margin-top: 138x;
   }
 
   .footerBg {
@@ -33,13 +33,13 @@
   }
 
   [class*='footerLanding'] {
-    margin-top: -121px;
+    margin-top: -138px;
   }
 }
 
 @media (max-width: 700px) {
   .container {
-    margin-top: 147px;
+    margin-top: 164px;
   }
 
   .footerBg {
@@ -47,13 +47,13 @@
   }
 
   [class*='footerLanding'] {
-    margin-top: -147px;
+    margin-top: -164px;
   }
 }
 
 @media (max-width: 376px) {
   .container {
-    margin-top: 173px;
+    margin-top: 189px;
   }
 
   .footerBg {
@@ -61,6 +61,6 @@
   }
 
   [class*='footerLanding'] {
-    margin-top: -173px;
+    margin-top: -189px;
   }
 }

--- a/packages/audiodocs/src/theme/Footer/index.js
+++ b/packages/audiodocs/src/theme/Footer/index.js
@@ -14,7 +14,7 @@ export default function Footer(props) {
     const link = document.createElement('a');
     link.href = PRIVACY_POLICY_URL;
     link.target = '_blank';
-    link.rel = 'noopener noreferrer';
+    link.rel = 'noopener';
     link.dataset.privacyPolicy = '';
     link.textContent = 'Privacy Policy';
     paragraph.appendChild(link);

--- a/packages/audiodocs/src/theme/Footer/index.js
+++ b/packages/audiodocs/src/theme/Footer/index.js
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { Footer as TRexFooter } from '@swmansion/t-rex-ui';
+
+const PRIVACY_POLICY_URL = 'https://swmansion.com/privacy/policy/';
+
+export default function Footer(props) {
+  useEffect(() => {
+    const paragraph = document.querySelector('footer .footer__copyright p');
+    if (!paragraph || paragraph.querySelector('[data-privacy-policy]')) {
+      return;
+    }
+
+    paragraph.appendChild(document.createTextNode(' '));
+    const link = document.createElement('a');
+    link.href = PRIVACY_POLICY_URL;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.dataset.privacyPolicy = '';
+    link.textContent = 'Privacy Policy';
+    paragraph.appendChild(link);
+    paragraph.appendChild(document.createTextNode('.'));
+  }, []);
+
+  return <TRexFooter {...props} />;
+}


### PR DESCRIPTION
## Summary

* Adds a Privacy Policy link in the docs site footer
* Centers footer copyright content
* Fixes footer bottom padding and landing footer spacing across breakpoints

## Test Plan

- [ ] Confirm the footer shows the Privacy Policy link and opens `https://swmansion.com/privacy/policy/` in a new tab
- [ ] Check copyright text is centered on desktop and mobile
- [ ] Verify footer padding looks correct at common widths (desktop, tablet, phone)
- [ ] On the landing page, confirm footer/background spacing still lines up after the layout tweaks
<img width="1126" height="803" alt="image" src="https://github.com/user-attachments/assets/271114b7-ea5a-46f8-960a-ec49e32b94fb" />
