### PR TITLE
fix: detectHttpByteRanges should still try a Range GET after an inconclusive HEAD

### DIFF
--- a/packages/react-native-audio-api/src/utils/remoteHttpSource.ts
+++ b/packages/react-native-audio-api/src/utils/remoteHttpSource.ts
@@ -15,16 +15,16 @@ async function detectHttpByteRanges(
 ): Promise<boolean> {
   try {
     const headResponse = await fetch(url, { method: 'HEAD', headers });
-    if (headResponse.ok) {
-      const acceptRanges = headResponse.headers
-        .get('Accept-Ranges')
-        ?.toLowerCase();
-      if (acceptRanges === 'bytes') {
-        return true;
-      }
-
-      return false;
+    const acceptRanges = headResponse.headers
+      .get('Accept-Ranges')
+      ?.toLowerCase();
+    if (acceptRanges === 'bytes') {
+      return true;
     }
+    // HEAD succeeded but didn't confirm ranges (or wasn't ok) — some servers
+    // (e.g. several Icecast/Shoutcast configurations) omit Accept-Ranges from
+    // HEAD while still honoring a Range GET, so don't conclude "unsupported"
+    // without trying that too.
   } catch {
     // HEAD may be blocked or unsupported — fall through to a Range GET probe.
   }

--- a/packages/react-native-audio-api/tests/remote-http-source.test.ts
+++ b/packages/react-native-audio-api/tests/remote-http-source.test.ts
@@ -54,6 +54,62 @@ describe('loadRemoteHttpSource', () => {
     });
   });
 
+  it('falls through to a Range GET probe when HEAD succeeds without confirming Accept-Ranges', async () => {
+    isFfmpegEnabledMock.mockReturnValue(true);
+    fetchMock.mockImplementation(
+      async (_url: string, options?: { method?: string }) => {
+        if (options?.method === 'HEAD') {
+          // Some Icecast/Shoutcast servers omit Accept-Ranges from HEAD even
+          // though they honor a Range GET — confirmed against a real public
+          // stream (SomaFM) during the aiirmobile investigation.
+          return { ok: true, headers: { get: () => null } };
+        }
+        return { ok: true, status: 206 };
+      }
+    );
+
+    await expect(
+      loadRemoteHttpSource('https://example.com/stream.mp3')
+    ).resolves.toBe('https://example.com/stream.mp3');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://example.com/stream.mp3',
+      { method: 'HEAD', headers: undefined }
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://example.com/stream.mp3',
+      { headers: { Range: 'bytes=0-0' } }
+    );
+  });
+
+  it('downloads when neither HEAD nor a Range GET confirm byte-range support', async () => {
+    isFfmpegEnabledMock.mockReturnValue(true);
+    const buffer = new ArrayBuffer(4);
+    fetchMock.mockImplementation(
+      async (
+        _url: string,
+        options?: { method?: string; headers?: { Range?: string } }
+      ) => {
+        if (options?.method === 'HEAD') {
+          return { ok: true, headers: { get: () => null } };
+        }
+        if (options?.headers?.Range) {
+          return { ok: true, status: 200 }; // server ignored the Range request
+        }
+        return { ok: true, arrayBuffer: async () => buffer };
+      }
+    );
+
+    await expect(
+      loadRemoteHttpSource('https://example.com/stream.mp3')
+    ).resolves.toBe(buffer);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it('downloads when forceDownload is true even if byte ranges work', async () => {
     isFfmpegEnabledMock.mockReturnValue(true);
     const buffer = new ArrayBuffer(8);


### PR DESCRIPTION
## What

`detectHttpByteRanges()`'s own docstring says it does "HEAD, then Range probe" — but the code only tried the Range GET fallback when the HEAD request itself *threw*. Any HEAD response that merely succeeded, even without an `Accept-Ranges: bytes` header, was treated as decisive proof of "no range support," short-circuiting before the documented fallback probe ever ran.

## Why this matters

This misdetects real servers. Confirmed against a live public Icecast stream (SomaFM):

```
$ curl -I https://ice1.somafm.com/groovesalad-128-mp3
HTTP/1.1 200 OK
...no Accept-Ranges header...

$ curl -H "Range: bytes=0-0" https://ice1.somafm.com/groovesalad-128-mp3
HTTP/1.1 206 Partial Content
Accept-Ranges: bytes
Content-Range: bytes 0-0/1073741823
```

The server answers a Range GET with a genuine `206`, but its `HEAD` response never mentions ranges at all — a common pattern for Icecast/Shoutcast configs. Under the current logic, `detectHttpByteRanges` gives up right after the HEAD check and never finds this out, so `loadRemoteHttpSource` falls back to `downloadRemoteHttpSource()`, which calls `response.arrayBuffer()` — and for a genuinely indefinite live stream, that promise never resolves.

## The fix

Only short-circuit to `true` when `Accept-Ranges: bytes` is actually confirmed on the HEAD response. Any other outcome (HEAD ok-but-inconclusive, non-ok, or thrown) now falls through to the Range GET probe, matching the function's own documented behavior. Minimal diff, no behavior change for the cases that were already working correctly.

## Testing

- Two new Jest cases: one confirming the fallback now runs and correctly detects range support via the Range GET when HEAD is inconclusive, one confirming the genuinely-no-ranges case (neither HEAD nor Range GET confirm support) still correctly falls back to a full download. Full suite: 81/81 passing.
- `typecheck` / `lint:js`: clean.
- **Verified against the real repro, before and after this change**: loading `https://ice1.somafm.com/groovesalad-128-mp3` through `loadRemoteHttpSource()` (FFmpeg enabled) never resolved before this fix; it resolves in <1s after.

## What this doesn't fix

The FFmpeg-*disabled* path skips byte-range detection entirely by design (`if (!isFfmpegEnabled() || forceDownload) return downloadRemoteHttpSource(...)`), so it still hangs on the same URL — that's unrelated to this bug and not something this PR claims to address. For servers that genuinely don't support ranges at all (not just omit the header), there's still no way for a caller to say "this is a live stream, don't try to buffer it" up front. I'd like to follow up with that as a separate PR (an explicit hint on `AudioURISource`) once this one's settled, rather than combine the two.
