### PR TITLE
Escape the JSON-LD against early script termination

### DIFF
--- a/packages/audiodocs/plugins/swm-geo.js
+++ b/packages/audiodocs/plugins/swm-geo.js
@@ -116,7 +116,9 @@ module.exports = function swmGeoPlugin(context) {
           {
             tagName: 'script',
             attributes: { type: 'application/ld+json' },
-            innerHTML: JSON.stringify(buildStructuredData(context.siteConfig)),
+            innerHTML: JSON.stringify(
+              buildStructuredData(context.siteConfig),
+            ).replace(/</g, '\\u003c'),
           },
         ],
       };


### PR DESCRIPTION
Follow-up to #1244.

`JSON.stringify` leaves `<` unescaped, so a `</script>` inside any `siteConfig` value would close the script tag early. Escaped to `\u003c`.

Raised by Copilot on the same plugin in react-native-enriched-html#782; this is the same one-line fix.