### PR TITLE
fix: lazy init of audio engine

### DIFF
--- a/.claude/skills/turbo-modules/SKILL.md
+++ b/.claude/skills/turbo-modules/SKILL.md
@@ -152,6 +152,8 @@ Uses ObjC++ with `RCT_EXPORT_MODULE` and `RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD
 4. Create `AudioEventHandlerRegistry` (owns JS callbacks, needs runtime + callInvoker)
 5. Call `AudioAPIModuleInstaller::injectJSIBindings(...)`
 
+**Lazy `AVAudioEngine` invariant**: allocating the `AudioEngine` ObjC object at install does NOT create the underlying `AVAudioEngine`. It is created on demand by `createAudioEngineIfNeeded` (first node attach, engine start, rebuild), so apps that only use session management and notifications never allocate it. Every reader of `self.audioEngine` inside `AudioEngine.mm` must either nil-guard or call `createAudioEngineIfNeeded` first, and system-driven restart paths (`restartAudioEngine`) must not resurrect an engine when there is no tracked graph.
+
 **New Architecture support** (`getTurboModule`):
 ```objc
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.h
@@ -46,6 +46,7 @@ typedef NS_ENUM(NSInteger, AudioEngineState) {
 
 - (AudioEngineState)getState;
 - (bool)isEngineRunning;
+- (bool)isInUse;
 
 - (bool)startIfNecessary;
 - (void)pauseIfNecessary;

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
@@ -120,7 +120,6 @@ static AudioEngine *_sharedInstance = nil;
     self.inputRegistration = nil;
 
     self.sessionManager = [AudioSessionManager sharedInstance];
-    [self createAudioEngineIfNeeded];
   }
 
   _sharedInstance = self;
@@ -624,6 +623,14 @@ static AudioEngine *_sharedInstance = nil;
 - (void)restartAudioEngine
 {
   std::scoped_lock lock(_engineLock);
+
+  // The engine is created lazily on first node attach. Apps that only use
+  // session management and notifications never have one, and a system-driven
+  // restart (media services reset, configuration change) must not create it.
+  if (![self hasTrackedGraph] && self.audioEngine == nil) {
+    return;
+  }
+
   [self rebuildAudioEngineAndResumeIfNeeded];
 }
 

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/AudioEngine.mm
@@ -482,6 +482,12 @@ static AudioEngine *_sharedInstance = nil;
   return self.audioEngine != nil && [self.audioEngine isRunning];
 }
 
+- (bool)isInUse
+{
+  std::scoped_lock lock(_engineLock);
+  return [self hasTrackedGraph] || self.audioEngine != nil;
+}
+
 - (void)rebuildAudioEngineAndResumeIfNeeded
 {
   if (_isRebuildingAudioEngine) {

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/SystemNotificationManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/SystemNotificationManager.mm
@@ -222,11 +222,9 @@ static NSString *NotificationManagerContext = @"SystemNotificationManagerContext
   switch (routeChangeReason) {
     case AVAudioSessionRouteChangeReasonNewDeviceAvailable:
     case AVAudioSessionRouteChangeReasonOldDeviceUnavailable:
-    case AVAudioSessionRouteChangeReasonRouteConfigurationChange: {
-    handleEngineConfigurationChange:
-      nil;
+    case AVAudioSessionRouteChangeReasonRouteConfigurationChange:
+      [self handleEngineConfigurationChange:nil];
       break;
-    }
     default:
       break;
   }
@@ -240,8 +238,13 @@ static NSString *NotificationManagerContext = @"SystemNotificationManagerContext
   AudioSessionManager *sessionManager = self.audioAPIModule.audioSessionManager;
 
   dispatch_async(dispatch_get_main_queue(), ^{
+    bool wasSessionActive = sessionManager.isActive;
     [sessionManager markInactive];
-    [sessionManager ensureActive:true error:nil];
+
+    if (wasSessionActive) {
+      [sessionManager ensureActive:true error:nil];
+    }
+
     [audioEngine restartAudioEngine];
   });
 }

--- a/packages/react-native-audio-api/ios/audioapi/ios/system/SystemNotificationManager.mm
+++ b/packages/react-native-audio-api/ios/audioapi/ios/system/SystemNotificationManager.mm
@@ -232,10 +232,15 @@ static NSString *NotificationManagerContext = @"SystemNotificationManagerContext
 
 - (void)handleMediaServicesReset:(NSNotification *)notification
 {
-  NSLog(
-      @"[NotificationManager] Media services have been reset, tearing down and rebuilding everything.");
   AudioEngine *audioEngine = self.audioAPIModule.audioEngine;
   AudioSessionManager *sessionManager = self.audioAPIModule.audioSessionManager;
+
+  if (![audioEngine isInUse] && !sessionManager.isActive) {
+    return;
+  }
+
+  NSLog(
+      @"[NotificationManager] Media services have been reset, tearing down and rebuilding everything.");
 
   dispatch_async(dispatch_get_main_queue(), ^{
     bool wasSessionActive = sessionManager.isActive;
@@ -253,6 +258,14 @@ static NSString *NotificationManagerContext = @"SystemNotificationManagerContext
 {
   AudioEngine *audioEngine = self.audioAPIModule.audioEngine;
   AudioSessionManager *sessionManager = self.audioAPIModule.audioSessionManager;
+
+  // This notification is registered with object:nil, so it also fires for
+  // AVAudioEngine instances owned by other libraries in the host app. Without
+  // an engine of our own there is nothing to restart, and marking the session
+  // inactive would corrupt bookkeeping for apps that only manage the session.
+  if (![audioEngine isInUse]) {
+    return;
+  }
 
   dispatch_async(dispatch_get_main_queue(), ^{
     [sessionManager markInactive];


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- Removed `AudioEngine` allocation inside iOS audio-api module installation and restricted `AudioEngine` rebuild - apps that use react-native-audio-api only for session / notification management should not be forced to allocate it.
- Restricted session activation on media services reset - the audio session should not be activated after that notification if it had not been active beforehand.

## Introduced changes

<!-- A brief description of the changes -->

- Fixed typo in `SystemNotificationManager.mm` - `handleEngineConfigurationChange` was not invoked.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
