### PR TITLE
build: audio worklets packaging

### DIFF
--- a/apps/fabric-example/metro.config.js
+++ b/apps/fabric-example/metro.config.js
@@ -3,10 +3,11 @@ const path = require('path');
 
 const monorepoRoot = path.resolve(__dirname, '../..');
 const appsRoot = path.resolve(monorepoRoot, 'apps');
-const libraryRoot = path.resolve(
-  monorepoRoot,
-  'packages/react-native-audio-api'
-);
+const packagesRoot = path.resolve(monorepoRoot, 'packages');
+const workspacePackages = [
+  'react-native-audio-worklets',
+  'react-native-audio-api',
+];
 
 const defaultConfig = getDefaultConfig(__dirname);
 /**
@@ -22,9 +23,9 @@ const config = {
     resolveRequest: (context, moduleName, platform) => {
       // Override the consumer resolution to point to the source code
       // so that there is no need for manual rebuild on every change in TS.
-      if (moduleName === 'react-native-audio-api') {
+      if (workspacePackages.includes(moduleName)) {
         return {
-          filePath: path.resolve(libraryRoot, 'src/index.ts'),
+          filePath: path.resolve(packagesRoot, moduleName, 'src/index.ts'),
           type: 'sourceFile',
         };
       }

--- a/packages/react-native-audio-worklets/package.json
+++ b/packages/react-native-audio-worklets/package.json
@@ -2,11 +2,37 @@
   "name": "react-native-audio-worklets",
   "version": "1.0.0",
   "description": "react-native-worklets integration for react-native-audio-api: WorkletNode for UI-thread audio visualization. Requires React Native New Architecture.",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "react-native": {
+        "types": "./lib/typescript/module/index.d.ts",
+        "default": "./lib/module/index.js"
+      },
+      "module": {
+        "types": "./lib/typescript/module/index.d.ts",
+        "default": "./lib/module/index.js"
+      },
+      "module-sync": {
+        "types": "./lib/typescript/module/index.d.ts",
+        "default": "./lib/module/index.js"
+      },
+      "default": {
+        "types": "./lib/typescript/commonjs/index.d.ts",
+        "default": "./lib/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "type": "commonjs",
   "source": "src/index",
-  "main": "lib/module/index",
-  "module": "lib/module/index",
-  "react-native": "src/index",
-  "types": "lib/typescript/index.d.ts",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
+  "react-native": "src/index.ts",
+  "types": "lib/typescript/commonjs/index.d.ts",
   "files": [
     "src/",
     "lib/",
@@ -39,7 +65,7 @@
     "format:android:kotlin": "ktlint -F 'android/src/main/java/**/*.kt'",
     "format:ios": "find ios/audioworklets -type f \\( -iname \"*.h\" -o -iname \"*.m\" -o -iname \"*.mm\" \\) | xargs clang-format -i",
     "format:common": "find common/cpp/ \\( -path 'common/cpp/clangd/build' -prune -o -type f \\( -iname \"*.h\" -o -iname \"*.cpp\" -o -iname \"*.hpp\" \\) -print \\) | xargs clang-format -i",
-    "build": "yarn workspace react-native-audio-api build && bob build"
+    "build": "./scripts/build.sh"
   },
   "keywords": [
     "react-native",
@@ -100,8 +126,21 @@
           "esm": true
         }
       ],
-      "typescript",
-      "commonjs"
+      [
+        "commonjs",
+        {
+          "esm": true
+        }
+      ],
+      [
+        "typescript",
+        {
+          "project": "tsconfig.json",
+          "tsc": "../../node_modules/.bin/tsc",
+          "esm": true,
+          "commonjs": true
+        }
+      ]
     ]
   },
   "codegenConfig": {

--- a/packages/react-native-audio-worklets/scripts/build.sh
+++ b/packages/react-native-audio-worklets/scripts/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+yarn workspace react-native-audio-api build
+
+bob build
+
+echo '{"type": "module"}' > lib/module/package.json


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## ⚠️ Breaking changes ⚠️

<!-- A brief description of the breaking changes -->

- N/A

## Introduced changes

<!-- A brief description of the changes -->

- updated `package.json` config in `react-native-audio-worklets` (basically mimics the main package config, follows-up: #1194)

<img width="1492" height="365" alt="obraz" src="https://github.com/user-attachments/assets/d3b4320b-69a7-4d5f-9499-bc4a32e8c779" />


- updated `metro.config.js` so that metro sources `ts` files directly (for reload dx, follows-up: #1242)

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added/Conducted relevant tests
- [ ] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file
