### PR TITLE
feat(android): implement setInputDevice, which was a no-op

### DIFF
--- a/apps/common-app/src/examples/Record/Record.tsx
+++ b/apps/common-app/src/examples/Record/Record.tsx
@@ -216,11 +216,19 @@ const Record: FC = () => {
   };
 
   const onSelect = useCallback(
-    (id: string) => {
+    async (id: string) => {
       const input = availableInputs.find((d) => d.id === id);
 
-      if (input) {
-        onSelectInput(input);
+      if (!input) {
+        return;
+      }
+
+      try {
+        await onSelectInput(input);
+      } catch (error) {
+        // Android refuses a switch while a recorder is running, and either
+        // platform refuses a device that went away between listing and picking.
+        Alert.alert('Input Device Error', `${error}`);
       }
     },
     [availableInputs, onSelectInput]

--- a/packages/audiodocs/docs/hooks/select-input.mdx
+++ b/packages/audiodocs/docs/hooks/select-input.mdx
@@ -14,7 +14,9 @@ The `useAudioInput` hook provides an interface for:
 - switching between different input devices
 
 :::info Platform support
-Input device selection is currently only supported on iOS. On Android, `useAudioInput` is implemented as a no-op: the hook will not list or switch input devices, and any selection calls will effectively be ignored.
+Input device selection works on iOS and on Android. The two platforms differ in when a selection takes effect: iOS reroutes the running session immediately, while Android binds the device as a capture stream opens, so the selection applies to recorders started afterwards. Calling `onSelectInput` on Android while a recorder is running or paused throws, rather than deferring the switch without saying so. Android device selection also needs the AAudio backend; see [`setInputDevice`](../system/audio-manager.mdx#setinputdevice).
+
+On Android, `currentInput` is `null` until a device is selected through this hook, because the platform does not report which input it would pick on its own.
 :::
 
 ## Signature

--- a/packages/audiodocs/docs/system/audio-manager.mdx
+++ b/packages/audiodocs/docs/system/audio-manager.mdx
@@ -167,7 +167,24 @@ Checks if notification permissions were previously granted.
 
 Checks currently used and available devices.
 
+On Android, `currentInputs` reports the device selected through [`setInputDevice`](#setinputdevice) and is empty until one is selected, since the platform does not report which input it would pick on its own. `currentOutputs` is always empty on Android.
+
 #### Returns `Promise<AudioDevicesInfo>`, which is resolved after receiving the answer from the system.
+
+### `setInputDevice`
+
+Selects the device that audio is captured from, using an `id` taken from `getDevicesInfo().availableInputs`.
+
+| Name | Type | Description |
+| :----: | :----: | :---- |
+| `deviceId` | `string` | Identifier of the input device to capture from. |
+
+The two platforms differ in when the selection takes effect:
+
+- **iOS** sets the session's preferred input, which reroutes a running session right away.
+- **Android** binds the device while an Oboe capture stream opens, so the selection applies to recorders started afterwards. Calling it while a recorder is running or paused rejects instead of deferring the switch silently: stop the recorder, select the device, then start it again. A paused recorder still holds its stream and resumes onto the same device, which is why it is refused too. Android also needs the AAudio backend, which is what Oboe picks on Android 8.1 and newer; a recorder that can only open through OpenSL ES fails to start with an explanatory message rather than recording from the wrong device. If the selected device disappears mid-recording, the recorder reports an error through `onError` instead of falling back to the built-in microphone.
+
+#### Returns `Promise<void>`, which is resolved once the device is selected and rejected when the device cannot be found, when the system fails to switch to it, or, on Android, when a recorder is running or paused.
 
 ## Remarks
 
@@ -329,7 +346,7 @@ export type AudioDeviceList = AudioDeviceInfo[];
 export interface AudioDevicesInfo {
   availableInputs: AudioDeviceList;
   availableOutputs: AudioDeviceList;
-  currentInputs: AudioDeviceList; // iOS
+  currentInputs: AudioDeviceList; // iOS, and Android once a device is selected
   currentOutputs: AudioDeviceList; // iOS
 }
 ```

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/AudioAPIModule.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/AudioAPIModule.cpp
@@ -1,5 +1,6 @@
 #include <audioapi/android/AudioAPIModule.h>
 #include <audioapi/android/JniEventPayloadParser.h>
+#include <audioapi/android/core/AudioInputSelection.h>
 #include <audioapi/android/system/NativeFileInfo.hpp>
 #include <memory>
 
@@ -32,6 +33,7 @@ void AudioAPIModule::registerNatives() {
       makeNativeMethod(
           "invokeHandlerWithEventNameAndEventBody",
           AudioAPIModule::invokeHandlerWithEventNameAndEventBody),
+      makeNativeMethod("setPreferredInputDeviceId", AudioAPIModule::setPreferredInputDeviceId),
   });
 }
 
@@ -53,6 +55,11 @@ void AudioAPIModule::invokeHandlerWithEventNameAndEventBody(
   auto event = static_cast<AudioEvent>(eventOrdinal);
   audioEventHandlerRegistry_->dispatchEvent(
       event, kBroadcastListenerId, buildPayloadFromJniMap(event, eventBody));
+}
+
+jboolean AudioAPIModule::setPreferredInputDeviceId(jint deviceId) {
+  return static_cast<jboolean>(
+      AudioInputSelection::setPreferredDeviceId(static_cast<int32_t>(deviceId)));
 }
 
 } // namespace audioapi

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/AudioAPIModule.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/AudioAPIModule.h
@@ -26,6 +26,12 @@ class AudioAPIModule : public jni::HybridClass<AudioAPIModule> {
       jint eventOrdinal,
       jni::alias_ref<jni::JMap<jstring, jobject>> eventBody);
 
+  /// @brief Hands the capture device chosen through AudioManager.setInputDevice
+  /// to the recorders.
+  /// @returns false when a capture stream is already running, in which case the
+  /// selection is left unchanged. See AudioInputSelection.
+  jboolean setPreferredInputDeviceId(jint deviceId);
+
  private:
   friend HybridBase;
 

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.cpp
@@ -1,5 +1,6 @@
 #include <android/log.h>
 #include <audioapi/android/core/AndroidAudioRecorder.h>
+#include <audioapi/android/core/AudioInputSelection.h>
 #include <audioapi/android/core/utils/AndroidFileWriterBackend.h>
 #include <audioapi/android/core/utils/AndroidRecorderCallback.h>
 
@@ -51,6 +52,30 @@ std::optional<oboe::InputPreset> inputPresetFromString(const std::string &name) 
   }
   return std::nullopt;
 }
+
+/// Runs an action on scope exit unless it is dismissed first, so that a
+/// multi-step operation can undo a claim it took up front without repeating
+/// the undo on every failure path.
+template <typename Action>
+class ScopeExit {
+ public:
+  explicit ScopeExit(Action action) : action_(std::move(action)) {}
+  ~ScopeExit() {
+    if (armed_) {
+      action_();
+    }
+  }
+
+  DELETE_COPY_AND_MOVE(ScopeExit);
+
+  void dismiss() {
+    armed_ = false;
+  }
+
+ private:
+  Action action_;
+  bool armed_ = true;
+};
 } // namespace
 
 AndroidAudioRecorder::AndroidAudioRecorder(
@@ -60,7 +85,8 @@ AndroidAudioRecorder::AndroidAudioRecorder(
       inputPreset_(std::move(options.androidInputPreset)),
       streamSampleRate_(0.0),
       streamChannelCount_(0),
-      streamMaxBufferSizeInFrames_(0) {}
+      streamMaxBufferSizeInFrames_(0),
+      streamDeviceId_(AudioInputSelection::kSystemDefaultDeviceId) {}
 
 /// @brief Destructor ensures that the audio stream and each output type are closed and flushed up remaining data.
 /// callable from the JS thread or handled by audio thread (if js dropped recorder first).
@@ -87,12 +113,25 @@ AndroidAudioRecorder::~AndroidAudioRecorder() {
 /// @brief Creates and opens the Oboe audio input stream for recording.
 /// calculates the "native" or hardware stream parameters for other interfaces
 /// to use.
-/// Callable from the JS thread only.
+/// Callable from the JS thread, and from the Oboe error thread through
+/// onErrorAfterClose().
+/// The stream is opened on the device chosen through AudioInputSelection; an
+/// already open stream bound to a different device is replaced, since Oboe
+/// binds the capture device while the stream opens.
 /// @returns Success status or Error status with message.
 Result<NoneType, std::string> AndroidAudioRecorder::openAudioStream() {
   std::scoped_lock streamLock(streamMutex_);
+
+  const int32_t preferredDeviceId = AudioInputSelection::getPreferredDeviceId();
+
   if (mStream_ != nullptr) {
-    return Result<NoneType, std::string>::Ok(None);
+    if (streamDeviceId_ == preferredDeviceId) {
+      return Result<NoneType, std::string>::Ok(None);
+    }
+
+    mStream_->requestStop();
+    mStream_->close();
+    mStream_.reset();
   }
 
   oboe::AudioStreamBuilder builder;
@@ -109,6 +148,10 @@ Result<NoneType, std::string> AndroidAudioRecorder::openAudioStream() {
     builder.setInputPreset(*preset);
   }
 
+  if (preferredDeviceId != AudioInputSelection::kSystemDefaultDeviceId) {
+    builder.setDeviceId(preferredDeviceId);
+  }
+
   auto result = builder.openStream(mStream_);
 
   if (result != oboe::Result::OK || mStream_ == nullptr) {
@@ -116,6 +159,27 @@ Result<NoneType, std::string> AndroidAudioRecorder::openAudioStream() {
         "Failed to open audio stream: " + std::string(oboe::convertToText(result)));
   }
 
+  // Oboe honours setDeviceId on the AAudio backend only; OpenSL ES drops the
+  // request and reports kUnspecified instead (see AudioStreamBuilder::setDeviceId).
+  // Recording from a device the caller did not ask for is worse than not
+  // recording at all, so the stream is dropped and the open reported as failed.
+  if (preferredDeviceId != AudioInputSelection::kSystemDefaultDeviceId &&
+      mStream_->getDeviceId() != preferredDeviceId) {
+    const int32_t openedDeviceId = mStream_->getDeviceId();
+
+    mStream_->close();
+    mStream_.reset();
+
+    std::string message = std::format(
+        "Input device {} was requested, but the capture stream opened on device {}. "
+        "Selecting an input device needs the AAudio backend; OpenSL ES ignores the request.",
+        preferredDeviceId,
+        openedDeviceId);
+
+    return Result<NoneType, std::string>::Err(std::move(message));
+  }
+
+  streamDeviceId_ = preferredDeviceId;
   streamSampleRate_ = static_cast<float>(mStream_->getSampleRate());
   streamChannelCount_ = mStream_->getChannelCount();
   streamMaxBufferSizeInFrames_ = mStream_->getBufferSizeInFrames();
@@ -137,6 +201,15 @@ Result<NoneType, std::string> AndroidAudioRecorder::start(const std::string &fil
   if (!isIdle()) {
     return Result<NoneType, std::string>::Err("Recorder is already recording");
   }
+
+  // Claim the input selection before reading it, and keep the claim for the
+  // whole attempt. setInputDevice runs on the React Native module thread while
+  // this body runs on the promise thread pool, so without the claim a selection
+  // could be accepted between openAudioStream() reading the current one and the
+  // stream actually running, leaving the recorder on the previous device with
+  // nothing reporting it.
+  setRunningCapture(true);
+  ScopeExit releaseCapture([this] { setRunningCapture(false); });
 
   auto streamResult = openAudioStream();
 
@@ -187,8 +260,29 @@ Result<NoneType, std::string> AndroidAudioRecorder::start(const std::string &fil
         "Failed to start stream: " + std::string(oboe::convertToText(result)));
   }
 
+  releaseCapture.dismiss();
   state_.store(RecorderState::Recording, std::memory_order_release);
   return Result<NoneType, std::string>::Ok(None);
+}
+
+/// @brief Adds or removes this recorder from AudioInputSelection's
+/// running-capture count.
+/// Takes streamMutex_, which is recursive, so it can be called from methods
+/// already holding it.
+void AndroidAudioRecorder::setRunningCapture(bool running) {
+  std::scoped_lock streamLock(streamMutex_);
+
+  if (countedAsRunningCapture_ == running) {
+    return;
+  }
+
+  countedAsRunningCapture_ = running;
+
+  if (running) {
+    AudioInputSelection::captureStarted();
+  } else {
+    AudioInputSelection::captureStopped();
+  }
 }
 
 /// @brief Stops the audio stream and finalizes any output (file writing, callback, adapter node).
@@ -220,6 +314,7 @@ AndroidAudioRecorder::stop() {
     }
 
     state_.store(RecorderState::Idle, std::memory_order_release);
+    setRunningCapture(false);
     lastCallbackFrameCount_.store(0, std::memory_order_release);
     mStream_->requestStop();
 
@@ -569,6 +664,7 @@ bool AndroidAudioRecorder::isIdle() const {
 void AndroidAudioRecorder::cleanup() {
   std::scoped_lock streamLock(streamMutex_);
   state_.store(RecorderState::Idle, std::memory_order_release);
+  setRunningCapture(false);
 
   if (mStream_ != nullptr) {
     mStream_->requestStop();
@@ -593,6 +689,14 @@ void AndroidAudioRecorder::onErrorAfterClose(oboe::AudioStream *stream, oboe::Re
 
     cleanup();
 
+    // Re-take the claim before the replacement stream reads the selection, and
+    // hold it until that stream is running. cleanup() above dropped it, and
+    // opening a device takes long enough that a setInputDevice landing in an
+    // unclaimed window would be accepted while this stream binds the previous
+    // device, leaving the API affirming a device that is not being recorded.
+    setRunningCapture(true);
+    ScopeExit releaseCapture([this] { setRunningCapture(false); });
+
     auto streamResult = openAudioStream();
 
     if (!streamResult.is_ok()) {
@@ -611,6 +715,7 @@ void AndroidAudioRecorder::onErrorAfterClose(oboe::AudioStream *stream, oboe::Re
     }
 
     mStream_->requestStart();
+    releaseCapture.dismiss();
     state_.store(RecorderState::Recording, std::memory_order_release);
   }
 }

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AndroidAudioRecorder.h
@@ -68,12 +68,24 @@ class AndroidAudioRecorder : public oboe::AudioStreamCallback,
   std::atomic<float> streamSampleRate_;
   int32_t streamChannelCount_;
   int32_t streamMaxBufferSizeInFrames_;
+  /// Selection mStream_ was opened for. Oboe binds the capture device while the
+  /// stream opens, so this is compared against the current selection to tell
+  /// whether an already open stream still points at the right device.
+  /// Guarded by streamMutex_.
+  int32_t streamDeviceId_;
 
   std::shared_ptr<oboe::AudioStream> mStream_;
   std::vector<std::string> recordingSegmentPaths_;
   /// Updated on the audio thread from each input callback `numFrames`.
   std::atomic<int32_t> lastCallbackFrameCount_{0};
+  /// Whether this recorder is counted among AudioInputSelection's running
+  /// captures. Guarded by streamMutex_.
+  bool countedAsRunningCapture_{false};
   Result<NoneType, std::string> openAudioStream();
+  /// Keeps AudioInputSelection's running-capture count in step with this
+  /// recorder, so that a device selection made mid-recording is refused rather
+  /// than silently deferred. Idempotent.
+  void setRunningCapture(bool running);
   std::shared_ptr<AudioFileWriter> createFileWriter(
       const std::shared_ptr<AudioFileProperties> &props);
   Result<NoneType, std::string> setupFileWriter(

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioInputSelection.cpp
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioInputSelection.cpp
@@ -1,0 +1,45 @@
+#include <audioapi/android/core/AudioInputSelection.h>
+
+#include <mutex>
+
+namespace audioapi::AudioInputSelection {
+
+namespace {
+/// Guards both values together, so setPreferredDeviceId decides and writes
+/// without a window in which a recorder could claim the selection in between.
+std::mutex selectionMutex;
+int32_t preferredDeviceId = kSystemDefaultDeviceId;
+int32_t runningCaptureCount = 0;
+} // namespace
+
+bool setPreferredDeviceId(int32_t deviceId) {
+  std::scoped_lock selectionLock(selectionMutex);
+
+  if (deviceId == preferredDeviceId) {
+    return true;
+  }
+
+  if (runningCaptureCount > 0) {
+    return false;
+  }
+
+  preferredDeviceId = deviceId;
+  return true;
+}
+
+int32_t getPreferredDeviceId() {
+  std::scoped_lock selectionLock(selectionMutex);
+  return preferredDeviceId;
+}
+
+void captureStarted() {
+  std::scoped_lock selectionLock(selectionMutex);
+  ++runningCaptureCount;
+}
+
+void captureStopped() {
+  std::scoped_lock selectionLock(selectionMutex);
+  --runningCaptureCount;
+}
+
+} // namespace audioapi::AudioInputSelection

--- a/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioInputSelection.h
+++ b/packages/react-native-audio-api/android/src/main/cpp/audioapi/android/core/AudioInputSelection.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <oboe/Oboe.h>
+#include <cstdint>
+
+namespace audioapi {
+
+/// @brief Process-wide choice of the capture device every AndroidAudioRecorder
+/// opens its input stream on, set from Kotlin by AudioManager.setInputDevice.
+///
+/// Android routes capture per process rather than per stream, and the selection
+/// arrives through the AudioAPIModule TurboModule, which knows nothing about the
+/// individual recorders. It therefore cannot live on a recorder and is kept here
+/// instead. Nothing in the shared common/cpp layer depends on it.
+///
+/// A stream reads the selection once, while it opens, and stays bound to that
+/// device until it is reopened. The running-capture count exists so that a
+/// selection made while a stream is running can be refused instead of being
+/// silently deferred to the next start().
+namespace AudioInputSelection {
+
+/// @brief Leaves the capture device to the platform, which is Oboe's default.
+constexpr int32_t kSystemDefaultDeviceId = oboe::kUnspecified;
+
+/// @param deviceId An Android AudioDeviceInfo id, or kSystemDefaultDeviceId to
+/// hand the choice back to the platform.
+/// @returns false when a capture stream is running and the requested device
+/// differs from the current selection. The selection is then left unchanged,
+/// because a running stream cannot be moved onto it.
+bool setPreferredDeviceId(int32_t deviceId);
+
+int32_t getPreferredDeviceId();
+
+/// @brief Reports that a recorder holds the selection: it is about to read it,
+/// or is already feeding audio from it. Must be paired with captureStopped(),
+/// including on teardown, and calls must balance.
+void captureStarted();
+void captureStopped();
+
+} // namespace AudioInputSelection
+} // namespace audioapi

--- a/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
+++ b/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/AudioAPIModule.kt
@@ -31,6 +31,7 @@ class AudioAPIModule(
   companion object {
     const val NAME = NativeAudioAPIModuleSpec.NAME
     private const val TAG = "AudioAPIModule"
+    private const val INPUT_DEVICE_ERROR = "E_INPUT_DEVICE"
   }
 
   val reactContext: WeakReference<ReactApplicationContext> = WeakReference(reactContext)
@@ -50,6 +51,15 @@ class AudioAPIModule(
     eventOrdinal: Int,
     eventBody: Map<String, Any>,
   )
+
+  /**
+   * Hands the selected capture device to the native recorders.
+   *
+   * Returns false when a capture stream is already running, in which case the
+   * selection is left untouched: Oboe binds the capture device while the stream
+   * opens, so a running stream cannot be moved onto another one.
+   */
+  private external fun setPreferredInputDeviceId(deviceId: Int): Boolean
 
   init {
     try {
@@ -172,12 +182,38 @@ class AudioAPIModule(
     promise.resolve(MediaSessionManager.getDevicesInfo())
   }
 
+  /**
+   * Selects the capture device every recorder opens its input stream on.
+   *
+   * Unlike iOS, which reroutes a live session, the selection is bound while an
+   * Oboe input stream opens. Changing it therefore only affects streams opened
+   * afterwards, and is rejected outright while a recorder holds a stream so that
+   * a caller never mistakes a deferred switch for an applied one. A paused
+   * recorder still holds its stream and resumes onto the same device, so it
+   * counts as holding one.
+   */
+  @RequiresApi(Build.VERSION_CODES.M)
   override fun setInputDevice(
     deviceId: String?,
     promise: Promise?,
   ) {
-    // TODO: noop for now, but it should be moved to upcoming
-    // audio engine implementation for android (duplex stream)
+    val device = deviceId?.let { MediaSessionManager.findInputDevice(it) }
+
+    if (device == null) {
+      promise?.reject(INPUT_DEVICE_ERROR, "Input device with id $deviceId not found", null)
+      return
+    }
+
+    if (!setPreferredInputDeviceId(device.id)) {
+      promise?.reject(
+        INPUT_DEVICE_ERROR,
+        "Cannot change the input device while a recorder is running or paused. Stop the recorder, select the device, then start it again.",
+        null,
+      )
+      return
+    }
+
+    MediaSessionManager.setPreferredInputDevice(device)
     promise?.resolve(null)
   }
 

--- a/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/system/MediaSessionManager.kt
+++ b/packages/react-native-audio-api/android/src/main/java/com/swmansion/audioapi/system/MediaSessionManager.kt
@@ -17,6 +17,7 @@ import androidx.core.content.ContextCompat
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 import com.swmansion.audioapi.AudioAPIModule
@@ -210,37 +211,70 @@ object MediaSessionManager {
     notificationManager.createNotificationChannel(mChannel)
   }
 
+  /**
+   * Capture device selected through `AudioManager.setInputDevice`, kept so that
+   * [getDevicesInfo] can report it back. It mirrors the selection held by the
+   * native capture layer, and `AudioAPIModule.setInputDevice` is the only writer
+   * of either.
+   *
+   * Null means no explicit selection was made and the platform picks the device.
+   * Android offers no way to learn which one that is before a stream opens, so
+   * `currentInputs` stays empty in that case.
+   *
+   * Written from the React Native module thread and read by whichever thread
+   * calls `getDevicesInfo`, hence volatile.
+   */
+  @Volatile
+  private var preferredInputDeviceId: Int? = null
+
+  @RequiresApi(Build.VERSION_CODES.M)
+  fun findInputDevice(deviceId: String): AudioDeviceInfo? =
+    this.audioManager
+      .getDevices(AudioManager.GET_DEVICES_INPUTS)
+      .firstOrNull { it.id.toString() == deviceId }
+
+  fun setPreferredInputDevice(device: AudioDeviceInfo) {
+    this.preferredInputDeviceId = device.id
+  }
+
   @RequiresApi(Build.VERSION_CODES.O)
   fun getDevicesInfo(): ReadableMap {
     val availableInputs = Arguments.createArray()
+    val currentInputs = Arguments.createArray()
     val availableOutputs = Arguments.createArray()
 
-    for (inputDevice in this.audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)) {
-      val deviceInfo = Arguments.createMap()
-      deviceInfo.putString("id", inputDevice.getId().toString())
-      deviceInfo.putString("name", inputDevice.productName.toString())
-      deviceInfo.putString("category", parseDeviceCategory(inputDevice))
+    val selectedInputDeviceId = this.preferredInputDeviceId
 
-      availableInputs.pushMap(deviceInfo)
+    for (inputDevice in this.audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)) {
+      availableInputs.pushMap(describeDevice(inputDevice))
+
+      if (inputDevice.id == selectedInputDeviceId) {
+        currentInputs.pushMap(describeDevice(inputDevice))
+      }
     }
 
     for (outputDevice in this.audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)) {
-      val deviceInfo = Arguments.createMap()
-      deviceInfo.putString("id", outputDevice.getId().toString())
-      deviceInfo.putString("name", outputDevice.productName.toString())
-      deviceInfo.putString("category", parseDeviceCategory(outputDevice))
-
-      availableOutputs.pushMap(deviceInfo)
+      availableOutputs.pushMap(describeDevice(outputDevice))
     }
 
     val devicesInfo = Arguments.createMap()
 
-    devicesInfo.putArray("currentInputs", Arguments.createArray())
+    devicesInfo.putArray("currentInputs", currentInputs)
     devicesInfo.putArray("currentOutputs", Arguments.createArray())
     devicesInfo.putArray("availableInputs", availableInputs)
     devicesInfo.putArray("availableOutputs", availableOutputs)
 
     return devicesInfo
+  }
+
+  @RequiresApi(Build.VERSION_CODES.O)
+  private fun describeDevice(device: AudioDeviceInfo): WritableMap {
+    val deviceInfo = Arguments.createMap()
+    deviceInfo.putString("id", device.id.toString())
+    deviceInfo.putString("name", device.productName.toString())
+    deviceInfo.putString("category", parseDeviceCategory(device))
+
+    return deviceInfo
   }
 
   @RequiresApi(Build.VERSION_CODES.O)
@@ -253,6 +287,9 @@ object MediaSessionManager {
       AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> "Wired Headphones"
       AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> "Bluetooth A2DP"
       AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> "Bluetooth SCO"
+      AudioDeviceInfo.TYPE_USB_DEVICE -> "USB Device"
+      AudioDeviceInfo.TYPE_USB_HEADSET -> "USB Headset"
+      AudioDeviceInfo.TYPE_USB_ACCESSORY -> "USB Accessory"
       else -> "Other (${device.type})"
     }
 

--- a/packages/react-native-audio-api/src/hooks/useAudioInput.ts
+++ b/packages/react-native-audio-api/src/hooks/useAudioInput.ts
@@ -18,9 +18,14 @@ const meaningfulReasons: RouteChangeReason[] = [
 
 /**
  * A hook that provides basic information and selection capabilities for audio
- * input devices on the system. (iOS only currently). The hook will
- * automatically listen for configuration changes and updates its state. If you
- * need more granular control, consider using the AudioManager API directly.
+ * input devices on the system. The hook will automatically listen for
+ * configuration changes and updates its state. If you need more granular
+ * control, consider using the AudioManager API directly.
+ *
+ * On Android the selection is bound while a capture stream opens, so
+ * `onSelectInput` throws while a recorder is running or paused, and
+ * `currentInput` stays null until a device is picked. See
+ * `AudioManager.setInputDevice`.
  *
  * @returns An object containing audio input information and selection
  *   capabilities

--- a/packages/react-native-audio-api/src/system/AudioManager.ts
+++ b/packages/react-native-audio-api/src/system/AudioManager.ts
@@ -125,6 +125,14 @@ class AudioManager implements IAudioManager {
    *
    * Resolves when the input device was set successfully and rejects when the
    * device cannot be found or the system fails to switch to it.
+   *
+   * On iOS the running session is rerouted right away. On Android the device is
+   * bound while a capture stream opens, so the selection applies to recorders
+   * started afterwards, and calling this while a recorder is running or paused
+   * rejects rather than deferring the switch silently. Android also needs the
+   * AAudio backend: a recorder that can only open through OpenSL ES fails to
+   * start with an explanatory message instead of recording from the wrong
+   * device.
    */
   async setInputDevice(deviceId: string): Promise<void> {
     await NativeAudioAPIModule.setInputDevice(deviceId);

--- a/packages/react-native-audio-api/src/system/types.ts
+++ b/packages/react-native-audio-api/src/system/types.ts
@@ -68,8 +68,14 @@ export type AudioDeviceList = AudioDeviceInfo[];
 export interface AudioDevicesInfo {
   availableInputs: AudioDeviceList;
   availableOutputs: AudioDeviceList;
-  currentInputs: AudioDeviceList; // iOS only
-  currentOutputs: AudioDeviceList; // iOS only
+  /**
+   * On iOS, the inputs of the current route. On Android, the device selected
+   * through `setInputDevice`, and empty until one is selected: the platform
+   * does not report which input it would pick on its own.
+   */
+  currentInputs: AudioDeviceList;
+  /** Outputs of the current route. Always empty on Android. */
+  currentOutputs: AudioDeviceList;
 }
 
 export interface IAudioManager {


### PR DESCRIPTION
## The bug

`AudioManager.setInputDevice` works on iOS and does nothing on Android — the module method is a `// TODO: noop for now` that resolves unconditionally. Capture stays on the platform default while the API reports success.

Known gap (the docs say so, and #734 was closed by #926 which shipped iOS only). I hit it building a feature that records a USB-connected instrument on a phone.

## The fix

`AudioInputSelection` holds the preferred device id for the process; `AndroidAudioRecorder::openAudioStream()` reads it and passes it to `oboe::AudioStreamBuilder::setDeviceId()`.

Process-wide rather than per-recorder because Android routes capture per process, and the selection arrives through the `AudioAPIModule` TurboModule, which holds no reference to any recorder. Nothing in `common/cpp` depends on it. I chose to make the existing cross-platform API work rather than add a `RecorderOptions.deviceId` that would diverge from iOS.

Two parts look like more than the job needs, so briefly:

**A stale stream is replaced, not reused.** `stop()` never closes the stream and `openAudioStream()` returned early whenever one existed — so a recorder reuses its first stream for every later `start()`. Setting the device only in the builder would work on the first recording and never again.

**A device that wasn't honoured fails the open.** Oboe applies `setDeviceId` on AAudio only and reports `kUnspecified` under OpenSL ES, so the opened stream's `getDeviceId()` is checked against the request and a mismatch closes the stream and errors. Recording from a device the caller didn't pick seemed worse than not recording. (Deliberately not forcing `setAudioApi(AAudio)` — Oboe's header calls that "extremely risky" on 8.0.)

**Nothing changes for callers who don't use it:** with no selection the value is `oboe::kUnspecified`, `setDeviceId` is never called, the readback is skipped, and the early return behaves exactly as before.

Also: `TYPE_USB_DEVICE` / `TYPE_USB_HEADSET` / `TYPE_USB_ACCESSORY` added to `parseDeviceCategory` (a USB interface enumerated as `"Other (11)"`), and `currentInputs` populated (it was always empty, so `useAudioInput` could never report the current device).

## Questions for you

1. **What should this do while a recorder is running?** iOS reroutes live. Android binds the device as the stream opens, so it can't. This rejects, telling the caller to stop → select → start, on the reasoning that resolving while silently deferring is the worse failure. A live restart means reopening the file, re-`prepare()`ing the callback at a possibly different sample rate and re-`init()`ing the adapter node while the audio thread is in `onAudioReady` — which looked like the duplex-stream work the TODO defers. **Say the word and I'll implement the reroute instead.**
2. **Clearing the preference** isn't possible on either platform today (iOS rejects a nil id before reaching `setPreferredInput:nil`; Android now mirrors that). I had a cross-platform fix and pulled it out — widening `deviceId` to `string | null` in the spec is your API call, not a bug fix. Happy to open it separately.
3. `android/src/oldarch/NativeAudioAPIModuleSpec.java` is hand-maintained and nothing in the repo compiles it. Untouched here, but it can drift from codegen silently.

## Verification

All green: `validate:android` (409 C++ tests, NDK build), `lint:cpp`, `lint:kotlin`, `lint:js`, `format:check:js`, `format:check:android:kotlin`, `typecheck`, `test:js` (79), `check-audio-enum-sync`.

**Not tested on a device.** The readback assert, the reconnect path and reject-while-paused are compiled and reasoned about, never executed on hardware. Happy to check anything specific if you can point me at it.

**`format:check` for C++ is red, but not from this PR** — android 24 / ios 50 / common 1325, identical counts at base commit `c12bd7c9`. My files appear in none of the lists. Measured with clang-format 23.1.0; older releases may report differently.

Left out to keep this focused: `TYPE_BLE_HEADSET` is API 31 and `parseDeviceCategory` is `@RequiresApi(O)`, so it needs an annotation bump.
