### PR TITLE
docs(audio-recorder): note that Android AEC also needs the playback path

### DIFF
--- a/packages/audiodocs/docs/inputs/audio-recorder.mdx
+++ b/packages/audiodocs/docs/inputs/audio-recorder.mdx
@@ -371,6 +371,23 @@ const audioRecorder = new AudioRecorder({
 });
 ```
 
+:::caution Android: the playback side matters too
+
+On Android the platform AEC engaged by `voiceCommunication` cancels against the
+**voice-communication output path**. Playback started from an `AudioContext`
+does not sit on that path — it defaults to `USAGE_MEDIA` — so on some devices
+the app's own output can still leak into the capture even with the input preset
+set correctly.
+
+If you are building barge-in style interaction and still hear the app
+transcribe itself, this is the likely cause. Progress is tracked in
+[#1254](https://github.com/software-mansion/react-native-audio-api/issues/1254).
+
+Testing note: verify through the **loudspeaker**, never headphones. Headphones
+remove the acoustic path entirely and hide the problem.
+
+:::
+
 ## Properties
 
 | Name | Type | Description |


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Refs #1254

## ⚠️ Breaking changes ⚠️

- None. Documentation only.

## Introduced changes

- Adds a caution to the AudioRecorder full-duplex section noting that on Android
  the input preset is only the capture half of echo cancellation.

The section currently presents

```tsx
new AudioRecorder({ androidInputPreset: 'voiceCommunication', iosVoiceProcessing: true })
```

as what a full-duplex app needs. That is complete on iOS. On Android the platform
AEC cancels against the **voice-communication output path**, and `AudioContext`
playback defaults to `USAGE_MEDIA`, so on some devices the app's own output still
reaches the microphone with the preset set correctly — which is what #1254
reports, with a proposed fix on the output builder.

This PR does not touch that behaviour: @closetcaiman said in the issue that the
approach needs thinking through, and this is only the documentation half
(suggestion 2 in the report), so it should not constrain that decision.

It also adds a testing note. Headphones remove the acoustic path entirely, so a
broken setup verified over headphones looks fixed — worth stating next to the
recommendation itself.

### How I ran into it

Building a voice assistant on `0.13.3`, which predates `androidInputPreset`, so
our Android capture never engaged the platform AEC at all and the session had to
stop listening while it spoke. Reading upstream to plan the upgrade, the docs
suggested the input preset alone would be enough; #1254 says otherwise. I have
not reproduced the output-path half on a device myself — the wording follows the
issue rather than asserting more than I verified, and is deliberately hedged
("on some devices").

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added/Conducted relevant tests — documentation only
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage — not applicable
- [ ] Added support for web — not applicable
- [ ] Updated old arch android spec file — not applicable
