### PR TITLE
fix: enforce spec limits for ConvolverNode.buffer and allow 32-channel buffers

### DIFF
--- a/packages/audiodocs/docs/effects/convolver-node.mdx
+++ b/packages/audiodocs/docs/effects/convolver-node.mdx
@@ -41,7 +41,7 @@ Inherits all properties from [`AudioNode`](../core/audio-node.mdx#properties).
 
 | Name | Type | Description |
 | :----: | :----: | :-------- |
-| `buffer` | [`AudioBuffer`](../sources/audio-buffer.mdx) | Associated AudioBuffer. |
+| `buffer` | [`AudioBuffer`](../sources/audio-buffer.mdx) | Associated AudioBuffer. Setting it throws `NotSupportedError` unless the buffer has 1, 2 or 4 channels and the same sample rate as the context. |
 | `normalize` | `boolean` | Whether the impulse response from the buffer will be scaled by an equal-power normalization when the buffer attribute is set. |
 
 :::caution

--- a/packages/react-native-audio-api/src/core/AudioBuffer.ts
+++ b/packages/react-native-audio-api/src/core/AudioBuffer.ts
@@ -92,7 +92,7 @@ export default class AudioBuffer implements AudioBufferLike {
     options: AudioBufferOptions
   ): IAudioBuffer {
     const { numberOfChannels = 1, length, sampleRate } = options;
-    if (numberOfChannels < 1 || numberOfChannels >= 32) {
+    if (numberOfChannels < 1 || numberOfChannels > 32) {
       throw new NotSupportedError(
         `The number of channels provided (${numberOfChannels}) is outside the range [1, 32]`
       );

--- a/packages/react-native-audio-api/src/core/ConvolverNode.ts
+++ b/packages/react-native-audio-api/src/core/ConvolverNode.ts
@@ -3,7 +3,11 @@ import { ConvolverOptions } from '../types';
 import type BaseAudioContext from './BaseAudioContext';
 import AudioNode from './AudioNode';
 import AudioBuffer from './AudioBuffer';
-import { ConvolverOptionsValidator } from '../utils/validation';
+import {
+  ConvolverOptionsValidator,
+  validateConvolverBufferChannelCount,
+  validateConvolverBufferSampleRate,
+} from '../utils/validation';
 
 export default class ConvolverNode extends AudioNode {
   private _buffer: AudioBuffer | null = null;
@@ -31,6 +35,15 @@ export default class ConvolverNode extends AudioNode {
       this._buffer = null;
       return;
     }
+
+    // Spec setter steps: the engine has no guard of its own, so an impulse
+    // response the convolution matrix is undefined for must be rejected here.
+    validateConvolverBufferChannelCount(buffer.numberOfChannels);
+    validateConvolverBufferSampleRate(
+      buffer.sampleRate,
+      this.context.sampleRate
+    );
+
     (this.node as IConvolverNode).setBuffer(buffer.buffer);
     this._buffer = buffer;
   }

--- a/packages/react-native-audio-api/src/utils/validation/convolver.ts
+++ b/packages/react-native-audio-api/src/utils/validation/convolver.ts
@@ -15,6 +15,17 @@ export function validateConvolverBufferChannelCount(
   }
 }
 
+export function validateConvolverBufferSampleRate(
+  bufferSampleRate: number,
+  contextSampleRate: number
+): void {
+  if (bufferSampleRate !== contextSampleRate) {
+    throw new NotSupportedError(
+      `The sample rate of the impulse response for ConvolverNode buffer (${bufferSampleRate}) must match the sample rate of its context (${contextSampleRate}).`
+    );
+  }
+}
+
 export const ConvolverOptionsValidator: OptionsValidator<ConvolverOptions> = {
   validate(options?: ConvolverOptions): void {
     if (!options?.buffer) {

--- a/packages/react-native-audio-api/src/utils/validation/index.ts
+++ b/packages/react-native-audio-api/src/utils/validation/index.ts
@@ -12,6 +12,7 @@ export {
 export {
   ConvolverOptionsValidator,
   validateConvolverBufferChannelCount,
+  validateConvolverBufferSampleRate,
 } from './convolver';
 
 export { OscillatorOptionsValidator } from './oscillator';

--- a/packages/react-native-audio-api/src/web-core/AudioBuffer.web.ts
+++ b/packages/react-native-audio-api/src/web-core/AudioBuffer.web.ts
@@ -73,7 +73,7 @@ export default class AudioBuffer implements AudioBufferLike {
     options: AudioBufferOptions
   ): globalThis.AudioBuffer {
     const { numberOfChannels = 1, length, sampleRate } = options;
-    if (numberOfChannels < 1 || numberOfChannels >= 32) {
+    if (numberOfChannels < 1 || numberOfChannels > 32) {
       throw new NotSupportedError(
         `The number of channels provided (${numberOfChannels}) is outside the range [1, 32]`
       );

--- a/packages/react-native-audio-api/src/web-core/AudioContext.web.ts
+++ b/packages/react-native-audio-api/src/web-core/AudioContext.web.ts
@@ -123,7 +123,7 @@ export default class AudioContext implements BaseAudioContext {
     length: number,
     sampleRate: number
   ): AudioBuffer {
-    if (numberOfChannels < 1 || numberOfChannels >= 32) {
+    if (numberOfChannels < 1 || numberOfChannels > 32) {
       throw new NotSupportedError(
         `The number of channels provided (${numberOfChannels}) is outside the range [1, 32]`
       );

--- a/packages/react-native-audio-api/src/web-core/OfflineAudioContext.web.ts
+++ b/packages/react-native-audio-api/src/web-core/OfflineAudioContext.web.ts
@@ -119,7 +119,7 @@ export default class OfflineAudioContext implements BaseAudioContext {
     length: number,
     sampleRate: number
   ): AudioBuffer {
-    if (numberOfChannels < 1 || numberOfChannels >= 32) {
+    if (numberOfChannels < 1 || numberOfChannels > 32) {
       throw new NotSupportedError(
         `The number of channels provided (${numberOfChannels}) is outside the range [1, 32]`
       );

--- a/packages/react-native-audio-api/tests/convolver-buffer.test.ts
+++ b/packages/react-native-audio-api/tests/convolver-buffer.test.ts
@@ -1,0 +1,92 @@
+import AudioBuffer from '../src/core/AudioBuffer';
+import ConvolverNode from '../src/core/ConvolverNode';
+import { NotSupportedError } from '../src/errors';
+import type BaseAudioContext from '../src/core/BaseAudioContext';
+
+const CONTEXT_SAMPLE_RATE = 48000;
+
+function createContext(): BaseAudioContext {
+  return {
+    sampleRate: CONTEXT_SAMPLE_RATE,
+    context: {
+      createConvolver: () => ({
+        numberOfInputs: 1,
+        numberOfOutputs: 1,
+        normalize: true,
+        setBuffer: jest.fn(),
+      }),
+    },
+  } as unknown as BaseAudioContext;
+}
+
+function createBuffer(numberOfChannels: number, sampleRate: number) {
+  return new AudioBuffer({ numberOfChannels, length: 4, sampleRate });
+}
+
+beforeAll(() => {
+  globalThis.createAudioBuffer = jest.fn(
+    (numberOfChannels: number, length: number, sampleRate: number) => ({
+      length,
+      duration: length / sampleRate,
+      sampleRate,
+      numberOfChannels,
+      getChannelData: () => new Float32Array(length),
+      copyFromChannel: jest.fn(),
+      copyToChannel: jest.fn(),
+    })
+  ) as unknown as typeof globalThis.createAudioBuffer;
+});
+
+describe('AudioBuffer channel count bounds', () => {
+  // The spec requires an implementation to support at least 32 channels.
+  it.each([1, 2, 32])('accepts %i channels', (numberOfChannels) => {
+    expect(
+      createBuffer(numberOfChannels, CONTEXT_SAMPLE_RATE).numberOfChannels
+    ).toBe(numberOfChannels);
+  });
+
+  it.each([0, 33])('rejects %i channels', (numberOfChannels) => {
+    expect(() => createBuffer(numberOfChannels, CONTEXT_SAMPLE_RATE)).toThrow(
+      NotSupportedError
+    );
+  });
+});
+
+describe('ConvolverNode buffer setter', () => {
+  it.each([1, 2, 4])(
+    'accepts an impulse response with %i channels',
+    (channels) => {
+      const convolver = new ConvolverNode(createContext());
+      expect(() => {
+        convolver.buffer = createBuffer(channels, CONTEXT_SAMPLE_RATE);
+      }).not.toThrow();
+      expect(convolver.buffer?.numberOfChannels).toBe(channels);
+    }
+  );
+
+  it.each([3, 5, 6, 32])(
+    'rejects an impulse response with %i channels',
+    (channels) => {
+      const convolver = new ConvolverNode(createContext());
+      expect(() => {
+        convolver.buffer = createBuffer(channels, CONTEXT_SAMPLE_RATE);
+      }).toThrow(NotSupportedError);
+      expect(convolver.buffer).toBeNull();
+    }
+  );
+
+  it('rejects an impulse response whose sample rate differs from the context', () => {
+    const convolver = new ConvolverNode(createContext());
+    expect(() => {
+      convolver.buffer = createBuffer(1, CONTEXT_SAMPLE_RATE / 2);
+    }).toThrow(NotSupportedError);
+    expect(convolver.buffer).toBeNull();
+  });
+
+  it('accepts a null impulse response', () => {
+    const convolver = new ConvolverNode(createContext());
+    convolver.buffer = createBuffer(2, CONTEXT_SAMPLE_RATE);
+    convolver.buffer = null;
+    expect(convolver.buffer).toBeNull();
+  });
+});


### PR DESCRIPTION
No linked issue: found by reading source against the Web Audio API specification.

## ⚠️ Breaking changes ⚠️

Setting `ConvolverNode.buffer` to an impulse response with an unsupported
channel count, or with a sample rate different from the context's, now throws
`NotSupportedError` instead of silently configuring the convolver. This is the
behaviour the spec requires and the behaviour browsers already have, but code
that relied on the previous permissive setter will now see an exception.

## Introduced changes

- `ConvolverNode.buffer` setter now runs the spec's setter steps. Web Audio API
  §1.17.2: "If the buffer number of channels is not 1, 2, 4, or if the
  sample-rate of the buffer is not the same as the sample-rate of its associated
  BaseAudioContext, a NotSupportedError MUST be thrown." Previously the only
  channel-count check lived in `ConvolverOptionsValidator`, so it ran for a
  buffer passed through the constructor options and never for a later
  assignment. The sample-rate condition was not checked anywhere, and the native
  `ConvolverNodeHostObject::setBuffer` has no guard of its own, so a 31-channel
  impulse response was accepted and allocated one convolver per channel.
- `AudioBuffer` / `createBuffer` now accept 32 channels. The bound was written
  `numberOfChannels >= 32` while the error message on the next line reports the
  range as `[1, 32]` and `MAX_CHANNEL_COUNT` is inclusive everywhere else in the
  engine. §1.1.2 requires an implementation to support at least 32 channels.
  Same one-line fix in the three web-core copies.
- Added `tests/convolver-buffer.test.ts` covering both.

## Measurements

WPT smoke profile, before and after on the same build:

| | before | after |
| --- | --- | --- |
| overall | 2631/3301 | 2664/3303 |
| the-convolvernode-interface | 170/253 | 203/255 |

`wpt-compare.mjs` reports no regressions in any of the other 27 sections.

`convolver-channels.html` was aborting mid-task: it calls
`context.createBuffer(count, 1, sampleRate)` for count 1..32 outside the
`should()` wrapper, so the 32-channel call threw and killed the task at count
31. With both fixes it now passes all 32 of its assertions.
`ctor-convolver.html`'s "illegal sample rate buffer throws NotSupportedError"
also passes now; its three remaining failures are unrelated (missing
`DynamicsCompressorNode`, the `clamped-max` default for `channelCountMode`, and
`channelCount` option validation).

No render-path code changed. The new checks run in a JS property setter at
graph-configuration time, and no C++ file is touched.

## Splitting this, if you prefer

The two fixes are separable and I am happy to split them into two PRs on
request. The `AudioBuffer` bound is a strictly more permissive bug fix with no
behaviour change for anything that worked before; the `ConvolverNode` setter is
the actual behaviour change. They are bundled here only because
`convolver-channels.html` needs both to stop aborting, so neither one alone
makes that file pass.

## Checklist

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [x] Added support for web
- [ ] Updated old arch android spec file

On the three blank boxes: there is no issue to link, as noted at the top. The
WPT coverage summary is regenerated by maintainers with `yarn wpt:report:docs`,
which needs a second run against the published release in `apps/common-app`,
and the interface support table itself does not change here. The Android
old-arch spec file is unaffected, since no native or spec surface changed.
