### PR TITLE
fix: resume the audio context when a buffer source starts

### DIFF
--- a/packages/react-native-audio-api/src/core/AudioBufferQueueSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioBufferQueueSourceNode.ts
@@ -60,6 +60,7 @@ export default class AudioBufferQueueSourceNode extends AudioBufferBaseSourceNod
     this.state = AudioBufferQueueSourceState.PLAYING;
 
     (this.node as IAudioBufferQueueSourceNode).start(when, offset);
+    this.context.markRunningOnSourceStart();
   }
 
   public override stop(when: number = 0): void {

--- a/packages/react-native-audio-api/src/core/AudioBufferSourceNode.ts
+++ b/packages/react-native-audio-api/src/core/AudioBufferSourceNode.ts
@@ -112,6 +112,7 @@ export default class AudioBufferSourceNode extends AudioBufferBaseSourceNode {
 
     this.hasBeenStarted = true;
     (this.node as IAudioBufferSourceNode).start(when, offset, duration);
+    this.context.markRunningOnSourceStart();
   }
 
   public get onLoopEnded(): ((event: EventEmptyType) => void) | undefined {

--- a/packages/react-native-audio-api/tests/context-state-on-source-start.test.ts
+++ b/packages/react-native-audio-api/tests/context-state-on-source-start.test.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+import type { IAudioParam, IBaseAudioContext } from '../src/jsi-interfaces';
+
+type AudioContextExports = typeof import('../src/core/AudioContext');
+
+jest.mock('react-native', () => ({
+  Image: { resolveAssetSource: jest.fn() },
+  Platform: { OS: 'ios' },
+  TurboModuleRegistry: {
+    get: jest.fn(() => ({
+      install: jest.fn(),
+      getDevicePreferredSampleRate: jest.fn(() => 48000),
+    })),
+  },
+}));
+
+const SAMPLE_RATE = 48000;
+
+const createNativeParam = (): IAudioParam =>
+  ({
+    value: 0,
+    defaultValue: 0,
+    minValue: -3.4028235e38,
+    maxValue: 3.4028235e38,
+    setValueAtTime: jest.fn(),
+    linearRampToValueAtTime: jest.fn(),
+    exponentialRampToValueAtTime: jest.fn(),
+    setTargetAtTime: jest.fn(),
+    setValueCurveAtTime: jest.fn(),
+    cancelScheduledValues: jest.fn(),
+    cancelAndHoldAtTime: jest.fn(),
+    checkCurveExclusion: jest.fn(() => ({ status: 'success' })),
+  }) as unknown as IAudioParam;
+
+const createNativeNode = (extra: Record<string, unknown> = {}) => ({
+  numberOfInputs: 1,
+  numberOfOutputs: 1,
+  channelCount: 2,
+  channelCountMode: 'max',
+  channelInterpretation: 'speakers',
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+  onEnded: '0',
+  ...extra,
+});
+
+const createNativeListener = () => ({
+  positionX: createNativeParam(),
+  positionY: createNativeParam(),
+  positionZ: createNativeParam(),
+  forwardX: createNativeParam(),
+  forwardY: createNativeParam(),
+  forwardZ: createNativeParam(),
+  upX: createNativeParam(),
+  upY: createNativeParam(),
+  upZ: createNativeParam(),
+});
+
+const createNativeContext = () => {
+  const resume = jest.fn().mockResolvedValue(undefined);
+
+  const context = {
+    sampleRate: SAMPLE_RATE,
+    currentTime: 0,
+    state: 'suspended',
+    baseLatency: 0,
+    outputLatency: 0,
+    destination: createNativeNode(),
+    listener: createNativeListener(),
+    resume,
+    suspend: jest.fn().mockResolvedValue(undefined),
+    close: jest.fn().mockResolvedValue(undefined),
+    createOscillator: jest.fn(() =>
+      createNativeNode({
+        frequency: createNativeParam(),
+        detune: createNativeParam(),
+        type: 'sine',
+      })
+    ),
+    createBufferSource: jest.fn(() =>
+      createNativeNode({
+        detune: createNativeParam(),
+        playbackRate: createNativeParam(),
+        setBuffer: jest.fn(),
+        loop: false,
+        loopStart: 0,
+        loopEnd: 0,
+        loopSkip: false,
+      })
+    ),
+    createBufferQueueSource: jest.fn(() =>
+      createNativeNode({
+        detune: createNativeParam(),
+        playbackRate: createNativeParam(),
+        enqueueBuffer: jest.fn(),
+        dequeueBuffer: jest.fn(),
+        clearBuffers: jest.fn(),
+      })
+    ),
+  };
+
+  return { context: context as unknown as IBaseAudioContext, resume };
+};
+
+const loadAudioContext = (): AudioContextExports['default'] => {
+  return (require('../src/core/AudioContext') as AudioContextExports).default;
+};
+
+const setUpContext = () => {
+  const { context: nativeContext, resume } = createNativeContext();
+  globalThis.createAudioContext = jest.fn(
+    () => nativeContext
+  ) as unknown as typeof globalThis.createAudioContext;
+
+  const AudioContext = loadAudioContext();
+  return { context: new AudioContext({ sampleRate: SAMPLE_RATE }), resume };
+};
+
+describe('starting a source publishes the running context state', () => {
+  it.each([
+    [
+      'createOscillator',
+      (context: InstanceType<AudioContextExports['default']>) =>
+        context.createOscillator(),
+    ],
+    [
+      'createBufferSource',
+      (context: InstanceType<AudioContextExports['default']>) =>
+        context.createBufferSource(),
+    ],
+    [
+      'createBufferQueueSource',
+      (context: InstanceType<AudioContextExports['default']>) =>
+        context.createBufferQueueSource(),
+    ],
+  ])('%s', (_name, createSource) => {
+    const { context, resume } = setUpContext();
+
+    expect(context.state).toBe('suspended');
+    expect(resume).not.toHaveBeenCalled();
+
+    createSource(context).start();
+
+    expect(context.state).toBe('running');
+    expect(resume).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
No linked issue: found by reading `AudioScheduledSourceNode.start()` against
the two subclasses that override it.

## ⚠️ Breaking changes ⚠️

None.

## Introduced changes

`#1239` moved the implicit "a source started, so the driver is running now"
transition out of C++ and into JS. It deleted this block from
`AudioScheduledSourceNode::start()`:

```cpp
if (std::shared_ptr<BaseAudioContext> context = context_.lock()) {
  if (auto *audioContext = dynamic_cast<AudioContext *>(context.get())) {
    audioContext->start();
  }
}
```

and replaced it with `this.context.markRunningOnSourceStart()` in
`AudioScheduledSourceNode.start()`. The C++ hook covered every scheduled
source, because they all inherit that `start()`. The JS hook does not:
`AudioBufferSourceNode.start()` and `AudioBufferQueueSourceNode.start()`
override it (they take extra `offset` / `duration` arguments) and never call
the base or the hook, so nothing publishes the transition for them.
`AudioContext::start()` on the C++ side now has no callers at all.

Result, on a context that has not been resumed explicitly:

```js
const context = new AudioContext();
const source = context.createBufferSource();
source.buffer = buffer;
source.connect(context.destination);
source.start();

context.state; // 'suspended'
```

`context.state` stays `'suspended'` for the lifetime of the playback, and
`markRunningOnSourceStart()`'s `resume()` never reaches the native driver.
`context.createOscillator().start()` on the same context reports `'running'`,
because `OscillatorNode` does not override `start()`.

The fix adds the one call to both overrides. It is the same call
`Audio/AudioFileSourceNode.play()` already makes for exactly this reason, with
the comment `copied from audioscheduledsourcenode`. `markRunningOnSourceStart()`
is a no-op on `BaseAudioContext`, so `OfflineAudioContext` is unaffected, and
`AudioContext`'s override only acts while the state is `'suspended'`, so an
already-running context and a second `start()` call both stay no-ops.

## Tests

`tests/context-state-on-source-start.test.ts` drives the real
`core/AudioContext` over a stubbed JSI context and asserts, for each of
`createOscillator`, `createBufferSource` and `createBufferQueueSource`, that
the state is `'suspended'` with no `resume()` before `start()` and `'running'`
with exactly one `resume()` after it.

Without the fix, the oscillator case passes and both buffer cases fail with
`Expected: "running" / Received: "suspended"`. Removing
`markRunningOnSourceStart()` from `AudioScheduledSourceNode.start()` instead
turns all three red, so the assertions are not vacuous. Full suite: 82 passing.

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [ ] Updated Web Audio API coverage
- [ ] Added support for web
- [ ] Updated old arch android spec file

On the blank boxes: there is no issue to link, as noted at the top. No public
API, interface support or old-arch spec surface changes, so the docs, the
coverage table and the Android spec file are all unaffected. The web backend
delegates state entirely to the browser's own `AudioContext`, so `src/web-core`
has no equivalent hook to fix.
