### PR TITLE
fix: accept endTime of 0 in exponentialRampToValueAtTime

### DIFF
--- a/packages/react-native-audio-api/src/core/AudioParam.ts
+++ b/packages/react-native-audio-api/src/core/AudioParam.ts
@@ -76,7 +76,7 @@ export default class AudioParam {
       throw new RangeError(`value must be a non-zero number: ${value}`);
     }
 
-    if (endTime <= 0) {
+    if (endTime < 0) {
       throw new RangeError(
         `endTime must be a finite non-negative number: ${endTime}`
       );

--- a/packages/react-native-audio-api/tests/audio-param-scheduling.test.ts
+++ b/packages/react-native-audio-api/tests/audio-param-scheduling.test.ts
@@ -1,0 +1,82 @@
+/* eslint-disable */
+
+import AudioParam from '../src/core/AudioParam';
+import { RangeError } from '../src/errors';
+import type { IAudioParam } from '../src/jsi-interfaces';
+import type BaseAudioContext from '../src/core/BaseAudioContext';
+
+const createNativeParam = () =>
+  ({
+    value: 1,
+    defaultValue: 1,
+    minValue: -3.4028235e38,
+    maxValue: 3.4028235e38,
+    setValueAtTime: jest.fn(),
+    linearRampToValueAtTime: jest.fn(),
+    exponentialRampToValueAtTime: jest.fn(),
+    setTargetAtTime: jest.fn(),
+    setValueCurveAtTime: jest.fn(),
+    cancelScheduledValues: jest.fn(),
+    cancelAndHoldAtTime: jest.fn(),
+    checkCurveExclusion: jest.fn(() => ({ status: 'success' })),
+  }) as unknown as IAudioParam;
+
+describe('AudioParam scheduling', () => {
+  let nativeParam: IAudioParam;
+  let param: AudioParam;
+
+  beforeEach(() => {
+    nativeParam = createNativeParam();
+    // currentTime is 0 before an OfflineAudioContext starts rendering.
+    const context = { currentTime: 0 } as unknown as BaseAudioContext;
+    param = new AudioParam(nativeParam, context);
+    jest.clearAllMocks();
+  });
+
+  describe('exponentialRampToValueAtTime', () => {
+    it('accepts an endTime of 0', () => {
+      expect(() => param.exponentialRampToValueAtTime(0.5, 0)).not.toThrow();
+      expect(nativeParam.exponentialRampToValueAtTime).toHaveBeenCalledWith(
+        0.5,
+        0
+      );
+    });
+
+    it('throws RangeError for a negative endTime', () => {
+      expect(() => param.exponentialRampToValueAtTime(0.5, -1)).toThrow(
+        RangeError
+      );
+      expect(nativeParam.exponentialRampToValueAtTime).not.toHaveBeenCalled();
+    });
+
+    it('throws RangeError for a target value of 0', () => {
+      expect(() => param.exponentialRampToValueAtTime(0, 1)).toThrow(
+        RangeError
+      );
+      expect(nativeParam.exponentialRampToValueAtTime).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('endTime of 0 is accepted by every automation method', () => {
+    it('setValueAtTime', () => {
+      expect(() => param.setValueAtTime(0.5, 0)).not.toThrow();
+      expect(nativeParam.setValueAtTime).toHaveBeenCalledWith(0.5, 0);
+    });
+
+    it('linearRampToValueAtTime', () => {
+      expect(() => param.linearRampToValueAtTime(0.5, 0)).not.toThrow();
+      expect(nativeParam.linearRampToValueAtTime).toHaveBeenCalledWith(0.5, 0);
+    });
+
+    it('setTargetAtTime', () => {
+      expect(() => param.setTargetAtTime(0.5, 0, 1)).not.toThrow();
+      expect(nativeParam.setTargetAtTime).toHaveBeenCalledWith(0.5, 0, 1);
+    });
+
+    it('setValueCurveAtTime', () => {
+      const curve = new Float32Array([0, 1]);
+      expect(() => param.setValueCurveAtTime(curve, 0, 1)).not.toThrow();
+      expect(nativeParam.setValueCurveAtTime).toHaveBeenCalledWith(curve, 0, 1);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

`AudioParam.exponentialRampToValueAtTime` guards with `endTime <= 0`, so scheduling a ramp that ends at time 0 throws a `RangeError` instead of being accepted.

Minimal reproduction:

```js
const context = new OfflineAudioContext(1, 128, 48000);
const gain = context.createGain();

gain.gain.linearRampToValueAtTime(0.5, 0);      // ok
gain.gain.exponentialRampToValueAtTime(0.5, 0); // RangeError: endTime must be a finite non-negative number: 0
```

`context.currentTime` is still 0 for an `OfflineAudioContext` before rendering starts, so time 0 is a normal value to schedule at there.

### Spec

The Web Audio API defines the same constraint for `exponentialRampToValueAtTime` and `linearRampToValueAtTime` ([1.6.3 AudioParam](https://www.w3.org/TR/webaudio-1.1/#dom-audioparam-exponentialramptovalueattime), `endTime` argument):

> The time in the same time coordinate system as the `AudioContext`'s `currentTime` attribute where the exponential ramp ends. A `RangeError` exception MUST be thrown if `endTime` is negative or is not a finite number. If `endTime` is less than `currentTime`, it is clamped to `currentTime`.

`0` is not negative, so it must be accepted and then clamped.

### Root cause

The guard uses `<=` where the rest of the class uses `<`. Three other places in the repo already encode the non-negative rule and disagree with it: the `RangeError` message on that very branch says "must be a finite non-negative number", `src/web-core/AudioParam.web.ts` uses `endTime < 0`, and the docs table in `packages/audiodocs/docs/core/audio-param.mdx` lists the error as "`endTime` is negative number". So this only misbehaves on the native path.

### Tests

New `tests/audio-param-scheduling.test.ts` drives `src/core/AudioParam` against a fake `IAudioParam` and a context whose `currentTime` is 0. It asserts that `exponentialRampToValueAtTime(0.5, 0)` does not throw and forwards `(0.5, 0)` to the native param, that a negative `endTime` and a target `value` of 0 still throw `RangeError` and do not reach the native param, and that `setValueAtTime`, `linearRampToValueAtTime`, `setTargetAtTime` and `setValueCurveAtTime` all already accept time 0.

Suite goes from 79 to 86 tests; the first assertion fails against the current guard with `RangeError: endTime must be a finite non-negative number: 0`.

No docs change is needed, since the documented behaviour is already the corrected one.

## Checklist

- [ ] Linked relevant issue
- [x] Updated relevant documentation (already correct, no change needed)
- [x] Added/Conducted relevant tests
- [x] Performed self-review of the code
- [x] Updated Web Audio API coverage
- [x] Added support for web (`AudioParam.web.ts` was already correct)
- [x] Updated old arch android spec file (not applicable, JS-only change)
